### PR TITLE
Make data privacy classification part of schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/src/old-ecs/core-ecs/core-ecs-types.ts
+++ b/src/old-ecs/core-ecs/core-ecs-types.ts
@@ -160,6 +160,19 @@ export interface Table<C = { [K: string]: unknown }> {
 }
 
 /**
+ * A set of flags that can be used to control the privacy of the data.
+ */
+export interface UserPrivacyPreferences {
+/**
+ * Allows unsafe direct access to underlying attributes.
+ */
+  strictlyNecessary: boolean;
+  performance: boolean;
+  functional: boolean;
+  advertising: boolean;
+}
+
+/**
  * A column represents an array of values for a single component.
  * Each row in the column corresponds to a single entity within the containing Table.
  * The ECS stores data as a structure of arrays.

--- a/src/old-ecs/core-ecs/core-ecs-types.ts
+++ b/src/old-ecs/core-ecs/core-ecs-types.ts
@@ -160,19 +160,6 @@ export interface Table<C = { [K: string]: unknown }> {
 }
 
 /**
- * A set of flags that can be used to control the privacy of the data.
- */
-export interface UserPrivacyPreferences {
-/**
- * Allows unsafe direct access to underlying attributes.
- */
-  strictlyNecessary: boolean;
-  performance: boolean;
-  functional: boolean;
-  advertising: boolean;
-}
-
-/**
  * A column represents an array of values for a single component.
  * Each row in the column corresponds to a single entity within the containing Table.
  * The ECS stores data as a structure of arrays.

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -86,10 +86,8 @@ export interface Schema {
   /**
    * Classification of data according to privacy regulations and cookie consent frameworks.
    * Used to categorize data collection and processing for privacy compliance.
-   * Useful resources:
-   * https://git.corp.adobe.com/feds/privacy
-   * https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=adobedotcom&title=Consent+Management+Platform+Onboarding
-   * https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=adobedotcom&title=Domain+IDs+for+CMP+integration
+   * Useful resource:
+   * https://www.onetrust.com/products/cookie-consent/
    * 
    * @remarks
    * - `strictlyNecessary`: Essential data required for basic functionality and security

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -83,6 +83,7 @@ export interface Schema {
   allOf?: readonly Schema[];
   const?: any;
   enum?: readonly any[];
+  privacyClassification?: 'strictlyNecessary' | 'performance' | 'functional' | 'advertising';
 }
 
 export type FromSchemas<T> = {

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -83,7 +83,21 @@ export interface Schema {
   allOf?: readonly Schema[];
   const?: any;
   enum?: readonly any[];
-  privacyClassification?: 'strictlyNecessary' | 'performance' | 'functional' | 'advertising';
+  /**
+   * Classification of data according to privacy regulations and cookie consent frameworks.
+   * Used to categorize data collection and processing for privacy compliance.
+   * Useful resources:
+   * https://git.corp.adobe.com/feds/privacy
+   * https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=adobedotcom&title=Consent+Management+Platform+Onboarding
+   * https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=adobedotcom&title=Domain+IDs+for+CMP+integration
+   * 
+   * @remarks
+   * - `strictlyNecessary`: Essential data required for basic functionality and security
+   * - `performance`: Data used for analytics, performance monitoring, and site optimization  
+   * - `functional`: Data used for enhanced features and user experience improvements
+   * - `advertising`: Data used for advertising, marketing, and personalized content
+   */
+  privacy?: 'strictlyNecessary' | 'performance' | 'functional' | 'advertising';
 }
 
 export type FromSchemas<T> = {


### PR DESCRIPTION
## Description

* Make data privacy classification part of schema

## Related Issue
[Add privacy classification to schema](https://github.com/adobe/data/issues/40)

## Motivation and Context
By making the data aware of its privacy classification, it allows for filtering the data when serializing to JSON for storage in a single central location.

## How Has This Been Tested?
NA. Only updating the schema for now.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
