### PR TITLE
fix: toPromise leaks subscription on synchronous emission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.52",
+  "version": "0.9.53",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/observe/to-promise.test.ts
+++ b/packages/data/src/observe/to-promise.test.ts
@@ -1,0 +1,42 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, expect, test } from 'vitest';
+import { Observe } from './index.js';
+import { toPromise } from './to-promise.js';
+
+describe('toPromise', () => {
+    test('leaks subscription on synchronous emission', async () => {
+        let activeSubscribers = 0;
+
+        const source: Observe<string> = observer => {
+            activeSubscribers++;
+            observer('value');
+            return () => { activeSubscribers--; };
+        };
+
+        await toPromise(source);
+
+        expect(activeSubscribers).toBe(0);
+    });
+
+    test('second toPromise sees stale cached value after mutation', async () => {
+        let state = 'A';
+        const subscribers = new Set<(v: string) => void>();
+
+        const source: Observe<string> = observer => {
+            subscribers.add(observer);
+            observer(state);
+            return () => { subscribers.delete(observer); };
+        };
+
+        const cached = Observe.withCache(source);
+
+        const v1 = await toPromise(cached);
+        expect(v1).toBe('A');
+
+        state = 'B';
+        queueMicrotask(() => { for (const s of subscribers) s('B'); });
+
+        const v2 = await toPromise(cached);
+        expect(v2).toBe('B');
+    });
+});

--- a/packages/data/src/observe/to-promise.ts
+++ b/packages/data/src/observe/to-promise.ts
@@ -8,13 +8,18 @@ import { Observe, Unobserve } from "./index.js";
  * @returns the first value yielded by the observe function.
  */
 export function toPromise<T>(observable: Observe<T>): Promise<T> {
-  return new Promise<T>((resolve, _reject) => {
+  return new Promise<T>((resolve) => {
+    let resolved = false;
     let unobserve: Unobserve | null = null;
+    const tryUnobserve = () => {
+      if (unobserve) unobserve();
+      else queueMicrotask(tryUnobserve);
+    };
     unobserve = observable((value) => {
+      if (resolved) return;
+      resolved = true;
       resolve(value);
-      if (unobserve) {
-        unobserve();
-      }
+      tryUnobserve();
     });
   });
 }


### PR DESCRIPTION
## Summary

- `Observe.toPromise` was not calling its teardown when the observable emitted synchronously during subscribe — the normal case for `withCache`, `observe.select`, and `observeSelectDeep`
- The root cause: `unobserve` is still `null` when the callback fires synchronously, so the `if (unobserve)` guard skips the teardown and the subscription is never cleaned up
- The leaked subscription kept `withCache` open, causing a second `toPromise` on the same cached observable to receive the stale cached value instead of waiting for the updated one

**Fix:** defer teardown via `queueMicrotask` when `unobserve` is not yet assigned (sync-emit path); a `resolved` guard prevents re-entrancy from late emissions.

## Test plan

- [ ] `toPromise > leaks subscription on synchronous emission` — verifies `activeSubscribers` returns to 0 after `toPromise` resolves
- [ ] `toPromise > second toPromise sees stale cached value after mutation` — verifies a second `toPromise` on a `withCache`-wrapped observable resolves the updated value, not the stale one
- [ ] Full observe test suite (74 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)