### PR TITLE
feat(schema): add FractionalIndex type namespace

### DIFF
--- a/packages/data/src/schema/fractional-index/between-n.test.ts
+++ b/packages/data/src/schema/fractional-index/between-n.test.ts
@@ -1,0 +1,48 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { betweenN } from "./between-n.js";
+import type { FractionalIndex } from "./fractional-index.js";
+
+const fi = (s: string) => s as FractionalIndex;
+
+describe("betweenN", () => {
+    it("returns empty array for n = 0", () => {
+        expect(betweenN(undefined, undefined, 0)).toEqual([]);
+    });
+
+    it("generates n keys between undefined bounds", () => {
+        expect(betweenN(undefined, undefined, 5).join(" ")).toBe("a0 a1 a2 a3 a4");
+    });
+
+    it("generates n keys after a lower bound", () => {
+        expect(betweenN(fi("a4"), undefined, 10).join(" ")).toBe(
+            "a5 a6 a7 a8 a9 aA aB aC aD aE",
+        );
+    });
+
+    it("generates n keys before an upper bound", () => {
+        expect(betweenN(undefined, fi("a0"), 5).join(" ")).toBe("Zv Zw Zx Zy Zz");
+    });
+
+    it("generates n keys between two bounds (shared integer part)", () => {
+        expect(betweenN(fi("a0"), fi("a2"), 20).join(" ")).toBe(
+            "a04 a08 a0G a0K a0O a0V a0Z a0d a0l a0t a1 a14 a18 a1G a1O a1V a1Z a1d a1l a1t",
+        );
+    });
+
+    it("keys are in strictly ascending order", () => {
+        const keys = betweenN(fi("a0"), fi("b00"), 50);
+        for (let i = 1; i < keys.length; i++) {
+            expect(keys[i] > keys[i - 1]).toBe(true);
+        }
+    });
+
+    it("bulk insert of 500 keys grows length by at most 2 chars", () => {
+        const start = fi("a0");
+        const end = betweenN(start, undefined, 1)[0];
+        const keys = betweenN(start, end, 500);
+        const baseline = Math.max(start.length, end.length);
+        const maxLen = keys.reduce((m, k) => Math.max(m, k.length), 0);
+        expect(maxLen).toBe(baseline + 2);
+    });
+});

--- a/packages/data/src/schema/fractional-index/between-n.ts
+++ b/packages/data/src/schema/fractional-index/between-n.ts
@@ -1,0 +1,41 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import type { FractionalIndex } from "./fractional-index.js";
+import { keyBetween } from "./key-between.js";
+
+export const betweenN = (
+    a: FractionalIndex | undefined,
+    b: FractionalIndex | undefined,
+    n: number,
+): FractionalIndex[] => {
+    if (n === 0) return [];
+    if (n === 1) return [keyBetween(a, b)];
+
+    if (b === undefined) {
+        let c = keyBetween(a, b);
+        const result = [c];
+        for (let i = 0; i < n - 1; i++) {
+            c = keyBetween(c, b);
+            result.push(c);
+        }
+        return result;
+    }
+
+    if (a === undefined) {
+        let c = keyBetween(a, b);
+        const result = [c];
+        for (let i = 0; i < n - 1; i++) {
+            c = keyBetween(a, c);
+            result.push(c);
+        }
+        result.reverse();
+        return result;
+    }
+
+    const mid = Math.floor(n / 2);
+    const c = keyBetween(a, b);
+    return [
+        ...betweenN(a, c, mid),
+        c,
+        ...betweenN(c, b, n - mid - 1),
+    ];
+};

--- a/packages/data/src/schema/fractional-index/between.test.ts
+++ b/packages/data/src/schema/fractional-index/between.test.ts
@@ -1,0 +1,77 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { between } from "./between.js";
+import type { FractionalIndex } from "./fractional-index.js";
+
+const fi = (s: string) => s as FractionalIndex;
+
+describe("between", () => {
+    it("returns initial when both bounds are undefined", () => {
+        expect(between(undefined, undefined)).toBe("a0");
+    });
+
+    it("generates keys before an existing key", () => {
+        expect(between(undefined, fi("a0"))).toBe("Zz");
+        expect(between(undefined, fi("Y00"))).toBe("Xzzz");
+        expect(between(undefined, fi("a0V"))).toBe("a0");
+        expect(between(undefined, fi("b999"))).toBe("b99");
+        expect(between(undefined, fi("A000000000000000000000000001"))).toBe("A000000000000000000000000000V");
+    });
+
+    it("generates keys after an existing key", () => {
+        expect(between(fi("a0"), undefined)).toBe("a1");
+        expect(between(fi("bzz"), undefined)).toBe("c000");
+        expect(between(fi("zzzzzzzzzzzzzzzzzzzzzzzzzzy"), undefined)).toBe("zzzzzzzzzzzzzzzzzzzzzzzzzzz");
+        expect(between(fi("zzzzzzzzzzzzzzzzzzzzzzzzzzz"), undefined)).toBe("zzzzzzzzzzzzzzzzzzzzzzzzzzzV");
+    });
+
+    it("generates keys between two existing keys", () => {
+        expect(between(fi("a0"), fi("a1"))).toBe("a0V");
+        expect(between(fi("a0V"), fi("a1"))).toBe("a0l");
+        expect(between(fi("Zz"), fi("a0"))).toBe("ZzV");
+        expect(between(fi("Zz"), fi("a1"))).toBe("a0");
+        expect(between(fi("a0"), fi("a0V"))).toBe("a0G");
+        expect(between(fi("a0"), fi("a0G"))).toBe("a08");
+        expect(between(fi("b125"), fi("b129"))).toBe("b127");
+        expect(between(fi("a0"), fi("a1V"))).toBe("a1");
+        expect(between(fi("Zz"), fi("a01"))).toBe("a0");
+    });
+
+    it("throws for invalid key (smallest integer)", () => {
+        expect(() => between(undefined, fi("A00000000000000000000000000"))).toThrow("invalid order key");
+    });
+
+    it("throws for trailing zero in fractional part", () => {
+        expect(() => between(undefined, fi("b0"))).toThrow("invalid order key");
+        expect(() => between(fi("a00"), undefined)).toThrow("invalid order key");
+        expect(() => between(fi("a00"), fi("a1"))).toThrow("invalid order key");
+    });
+
+    it("throws when head is a digit instead of a letter", () => {
+        expect(() => between(fi("0"), fi("1"))).toThrow("Invalid order key head");
+    });
+
+    it("throws when a >= b", () => {
+        expect(() => between(fi("a1"), fi("a0"))).toThrow("Invalid key order: a >= b");
+    });
+
+    it("max length for 100k consecutive appends is 4 chars", () => {
+        let current: FractionalIndex = fi("a0");
+        let maxLen = current.length;
+        for (let i = 0; i < 100_000; i++) {
+            current = between(current, undefined);
+            if (current.length > maxLen) maxLen = current.length;
+        }
+        expect(maxLen).toBe(4);
+    });
+
+    it("max length for 500 consecutive head-inserts is 86 chars", () => {
+        let next: FractionalIndex | undefined;
+        let maxLen = 0;
+        for (let i = 0; i < 500; i++) {
+            next = between(fi("a0"), next);
+            if (next.length > maxLen) maxLen = next.length;
+        }
+        expect(maxLen).toBe(86);
+    });
+});

--- a/packages/data/src/schema/fractional-index/between.ts
+++ b/packages/data/src/schema/fractional-index/between.ts
@@ -1,0 +1,8 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import type { FractionalIndex } from "./fractional-index.js";
+import { keyBetween } from "./key-between.js";
+
+export const between = (
+    a: FractionalIndex | undefined,
+    b: FractionalIndex | undefined,
+): FractionalIndex => keyBetween(a, b);

--- a/packages/data/src/schema/fractional-index/decrement-integer.test.ts
+++ b/packages/data/src/schema/fractional-index/decrement-integer.test.ts
@@ -1,0 +1,35 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { decrementInteger } from "./decrement-integer.js";
+
+describe("decrementInteger", () => {
+    it("decrements simple keys", () => {
+        expect(decrementInteger("a1")).toBe("a0");
+        expect(decrementInteger("a2")).toBe("a1");
+    });
+
+    it("borrows across digit positions", () => {
+        expect(decrementInteger("b00")).toBe("az");
+        expect(decrementInteger("b10")).toBe("b0z");
+        expect(decrementInteger("b20")).toBe("b1z");
+        expect(decrementInteger("c000")).toBe("bzz");
+        expect(decrementInteger("dAC00")).toBe("dABzz");
+    });
+
+    it("crosses the positive/negative boundary", () => {
+        expect(decrementInteger("Zz")).toBe("Zy");
+        expect(decrementInteger("a0")).toBe("Zz");
+    });
+
+    it("handles transitions that lengthen the integer part (negative side)", () => {
+        expect(decrementInteger("Yzz")).toBe("Yzy");
+        expect(decrementInteger("Z0")).toBe("Yzz");
+        expect(decrementInteger("Xz00")).toBe("Xyzz");
+        expect(decrementInteger("Xz01")).toBe("Xz00");
+        expect(decrementInteger("Y00")).toBe("Xzzz");
+    });
+
+    it("returns undefined at the bottom of range", () => {
+        expect(decrementInteger("A00000000000000000000000000")).toBeUndefined();
+    });
+});

--- a/packages/data/src/schema/fractional-index/decrement-integer.ts
+++ b/packages/data/src/schema/fractional-index/decrement-integer.ts
@@ -1,0 +1,26 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { digits } from "./digits.js";
+import { validateInteger } from "./validate-integer.js";
+
+export const decrementInteger = (x: string): string | undefined => {
+    validateInteger(x);
+    const [head, ...digs] = x.split("");
+    let borrow = true;
+    for (let i = digs.length - 1; borrow && i >= 0; i--) {
+        const d = digits.indexOf(digs[i]) - 1;
+        if (d === -1) {
+            digs[i] = digits.slice(-1);
+        } else {
+            digs[i] = digits.charAt(d);
+            borrow = false;
+        }
+    }
+    if (borrow) {
+        if (head === "a") return "Z" + digits.slice(-1);
+        if (head === "A") return undefined;
+        const h = String.fromCharCode(head.charCodeAt(0) - 1);
+        if (h < "Z") digs.push(digits.slice(-1)); else digs.pop();
+        return h + digs.join("");
+    }
+    return head + digs.join("");
+};

--- a/packages/data/src/schema/fractional-index/digits.ts
+++ b/packages/data/src/schema/fractional-index/digits.ts
@@ -1,0 +1,2 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+export const digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";

--- a/packages/data/src/schema/fractional-index/fractional-index.ts
+++ b/packages/data/src/schema/fractional-index/fractional-index.ts
@@ -1,0 +1,6 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { ToType } from "../to-type.js";
+import { schema } from "./schema.js";
+
+export type FractionalIndex = ToType<typeof schema>;
+export * as FractionalIndex from "./public.js";

--- a/packages/data/src/schema/fractional-index/increment-integer.test.ts
+++ b/packages/data/src/schema/fractional-index/increment-integer.test.ts
@@ -1,0 +1,39 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { incrementInteger } from "./increment-integer.js";
+
+describe("incrementInteger", () => {
+    it("increments simple keys", () => {
+        expect(incrementInteger("a0")).toBe("a1");
+        expect(incrementInteger("a1")).toBe("a2");
+    });
+
+    it("carries across digit positions", () => {
+        expect(incrementInteger("az")).toBe("b00");
+        expect(incrementInteger("b0z")).toBe("b10");
+        expect(incrementInteger("b1z")).toBe("b20");
+        expect(incrementInteger("bzz")).toBe("c000");
+        expect(incrementInteger("dABzz")).toBe("dAC00");
+    });
+
+    it("crosses the negative/positive boundary", () => {
+        expect(incrementInteger("Zy")).toBe("Zz");
+        expect(incrementInteger("Zz")).toBe("a0");
+    });
+
+    it("handles transitions that shorten the integer part (negative side)", () => {
+        expect(incrementInteger("Yzy")).toBe("Yzz");
+        expect(incrementInteger("Yzz")).toBe("Z0");
+        expect(incrementInteger("Xyzz")).toBe("Xz00");
+        expect(incrementInteger("Xz00")).toBe("Xz01");
+        expect(incrementInteger("Xzzz")).toBe("Y00");
+    });
+
+    it("returns undefined at the top of range", () => {
+        expect(incrementInteger("zzzzzzzzzzzzzzzzzzzzzzzzzzz")).toBeUndefined();
+    });
+
+    it("throws on invalid integer length", () => {
+        expect(() => incrementInteger("b0")).toThrow("invalid integer part of order key");
+    });
+});

--- a/packages/data/src/schema/fractional-index/increment-integer.ts
+++ b/packages/data/src/schema/fractional-index/increment-integer.ts
@@ -1,0 +1,26 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { digits } from "./digits.js";
+import { validateInteger } from "./validate-integer.js";
+
+export const incrementInteger = (x: string): string | undefined => {
+    validateInteger(x);
+    const [head, ...digs] = x.split("");
+    let carry = true;
+    for (let i = digs.length - 1; carry && i >= 0; i--) {
+        const d = digits.indexOf(digs[i]) + 1;
+        if (d === digits.length) {
+            digs[i] = "0";
+        } else {
+            digs[i] = digits.charAt(d);
+            carry = false;
+        }
+    }
+    if (carry) {
+        if (head === "Z") return "a0";
+        if (head === "z") return undefined;
+        const h = String.fromCharCode(head.charCodeAt(0) + 1);
+        if (h > "a") digs.push("0"); else digs.pop();
+        return h + digs.join("");
+    }
+    return head + digs.join("");
+};

--- a/packages/data/src/schema/fractional-index/initial.ts
+++ b/packages/data/src/schema/fractional-index/initial.ts
@@ -1,0 +1,4 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import type { FractionalIndex } from "./fractional-index.js";
+
+export const initial: FractionalIndex = "a0";

--- a/packages/data/src/schema/fractional-index/integer-length.ts
+++ b/packages/data/src/schema/fractional-index/integer-length.ts
@@ -1,0 +1,6 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+export const integerLength = (head: string): number => {
+    if (head >= "a" && head <= "z") return head.charCodeAt(0) - "a".charCodeAt(0) + 2;
+    if (head >= "A" && head <= "Z") return "Z".charCodeAt(0) - head.charCodeAt(0) + 2;
+    throw new Error(`Invalid order key head: ${head}`);
+};

--- a/packages/data/src/schema/fractional-index/integer-part.ts
+++ b/packages/data/src/schema/fractional-index/integer-part.ts
@@ -1,0 +1,8 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { integerLength } from "./integer-length.js";
+
+export const integerPart = (key: string): string => {
+    const len = integerLength(key.charAt(0));
+    if (len > key.length) throw new Error("invalid order key");
+    return key.slice(0, len);
+};

--- a/packages/data/src/schema/fractional-index/key-between.ts
+++ b/packages/data/src/schema/fractional-index/key-between.ts
@@ -1,0 +1,43 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import type { FractionalIndex } from "./fractional-index.js";
+import { decrementInteger } from "./decrement-integer.js";
+import { incrementInteger } from "./increment-integer.js";
+import { integerPart } from "./integer-part.js";
+import { midpoint } from "./midpoint.js";
+import { smallestInteger } from "./smallest-integer.js";
+import { validateOrderKey } from "./validate-order-key.js";
+
+export const keyBetween = (
+    a: FractionalIndex | undefined,
+    b: FractionalIndex | undefined,
+): FractionalIndex => {
+    if (a !== undefined) validateOrderKey(a);
+    if (b !== undefined) validateOrderKey(b);
+    if (a !== undefined && b !== undefined && a >= b) {
+        throw new Error("Invalid key order: a >= b");
+    }
+
+    if (a === undefined && b === undefined) return "a0";
+
+    if (a === undefined) {
+        const ib = integerPart(b!);
+        const fb = b!.slice(ib.length);
+        if (ib === smallestInteger) return ib + midpoint("", fb);
+        return ib < b! ? ib : decrementInteger(ib)!;
+    }
+
+    if (b === undefined) {
+        const ia = integerPart(a);
+        const fa = a.slice(ia.length);
+        const i = incrementInteger(ia);
+        return i === undefined ? ia + midpoint(fa, undefined) : i;
+    }
+
+    const ia = integerPart(a);
+    const fa = a.slice(ia.length);
+    const ib = integerPart(b);
+    const fb = b.slice(ib.length);
+    if (ia === ib) return ia + midpoint(fa, fb);
+    const i = incrementInteger(ia)!;
+    return i < b ? i : ia + midpoint(fa, undefined);
+};

--- a/packages/data/src/schema/fractional-index/midpoint.test.ts
+++ b/packages/data/src/schema/fractional-index/midpoint.test.ts
@@ -1,0 +1,93 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { midpoint } from "./midpoint.js";
+
+const base10 = "0123456789";
+
+describe("midpoint", () => {
+    describe("base 10", () => {
+        it("finds midpoints toward upper end", () => {
+            expect(midpoint("", undefined, base10)).toBe("5");
+            expect(midpoint("5", undefined, base10)).toBe("8");
+            expect(midpoint("8", undefined, base10)).toBe("9");
+            expect(midpoint("9", undefined, base10)).toBe("95");
+            expect(midpoint("95", undefined, base10)).toBe("98");
+            expect(midpoint("98", undefined, base10)).toBe("99");
+            expect(midpoint("99", undefined, base10)).toBe("995");
+        });
+
+        it("finds midpoints between two values", () => {
+            expect(midpoint("1", "2", base10)).toBe("15");
+            expect(midpoint("001", "001002", base10)).toBe("001001");
+            expect(midpoint("001", "001001", base10)).toBe("0010005");
+            expect(midpoint("05", "1", base10)).toBe("08");
+            expect(midpoint("111", "1128", base10)).toBe("112");
+        });
+
+        it("finds midpoints from empty string to upper bound", () => {
+            expect(midpoint("", "5", base10)).toBe("3");
+            expect(midpoint("", "3", base10)).toBe("2");
+            expect(midpoint("", "2", base10)).toBe("1");
+        });
+
+        it("throws when a >= b", () => {
+            expect(() => midpoint("2", "1", base10)).toThrow("Invalid midpoint args: a >= b");
+            expect(() => midpoint("", "", base10)).toThrow("Invalid midpoint args: a >= b");
+            expect(() => midpoint("11", "1", base10)).toThrow("Invalid midpoint args: a >= b");
+        });
+
+        it("throws on trailing zero", () => {
+            expect(() => midpoint("0", "1", base10)).toThrow("trailing zero");
+            expect(() => midpoint("1", "10", base10)).toThrow("trailing zero");
+        });
+    });
+
+    describe("base 62", () => {
+        it("finds midpoints toward upper end", () => {
+            expect(midpoint("", undefined)).toBe("V");
+            expect(midpoint("V", undefined)).toBe("l");
+            expect(midpoint("l", undefined)).toBe("t");
+            expect(midpoint("t", undefined)).toBe("x");
+            expect(midpoint("x", undefined)).toBe("z");
+            expect(midpoint("z", undefined)).toBe("zV");
+            expect(midpoint("zV", undefined)).toBe("zl");
+            expect(midpoint("zl", undefined)).toBe("zt");
+            expect(midpoint("zt", undefined)).toBe("zx");
+            expect(midpoint("zx", undefined)).toBe("zz");
+            expect(midpoint("zz", undefined)).toBe("zzV");
+        });
+
+        it("finds midpoints between two values", () => {
+            expect(midpoint("1", "2")).toBe("1V");
+            expect(midpoint("001", "001002")).toBe("001001");
+            expect(midpoint("001", "001001")).toBe("001000V");
+            expect(midpoint("4zz", "5")).toBe("4zzV");
+        });
+
+        it("finds midpoints from empty string to upper bound", () => {
+            expect(midpoint("", "V")).toBe("G");
+            expect(midpoint("", "G")).toBe("8");
+            expect(midpoint("", "8")).toBe("4");
+            expect(midpoint("", "4")).toBe("2");
+            expect(midpoint("", "2")).toBe("1");
+            expect(midpoint("", "1")).toBe("0V");
+            expect(midpoint("0V", "1")).toBe("0l");
+            expect(midpoint("", "0G")).toBe("08");
+            expect(midpoint("", "08")).toBe("04");
+            expect(midpoint("", "04")).toBe("02");
+            expect(midpoint("", "02")).toBe("01");
+            expect(midpoint("", "01")).toBe("00V");
+        });
+
+        it("throws when a >= b", () => {
+            expect(() => midpoint("2", "1")).toThrow("Invalid midpoint args: a >= b");
+            expect(() => midpoint("", "")).toThrow("Invalid midpoint args: a >= b");
+            expect(() => midpoint("11", "1")).toThrow("Invalid midpoint args: a >= b");
+        });
+
+        it("throws on trailing zero", () => {
+            expect(() => midpoint("0", "1")).toThrow("trailing zero");
+            expect(() => midpoint("1", "10")).toThrow("trailing zero");
+        });
+    });
+});

--- a/packages/data/src/schema/fractional-index/midpoint.ts
+++ b/packages/data/src/schema/fractional-index/midpoint.ts
@@ -1,0 +1,19 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { digits as BASE_DIGITS } from "./digits.js";
+
+export const midpoint = (a: string, b: string | undefined, d = BASE_DIGITS): string => {
+    if (b !== undefined && a >= b) throw new Error("Invalid midpoint args: a >= b");
+    if (a.slice(-1) === "0" || (b && b.slice(-1) === "0")) throw new Error("trailing zero");
+
+    if (b) {
+        let n = 0;
+        while ((a.charAt(n) || "0") === b.charAt(n)) n++;
+        if (n > 0) return b.slice(0, n) + midpoint(a.slice(n), b.slice(n), d);
+    }
+
+    const digitA = a ? d.indexOf(a.charAt(0)) : 0;
+    const digitB = b !== undefined ? d.indexOf(b.charAt(0)) : d.length;
+    if (digitB - digitA > 1) return d.charAt(Math.round(0.5 * (digitA + digitB)));
+    if (b && b.length > 1) return b.slice(0, 1);
+    return d.charAt(digitA) + midpoint(a.slice(1), undefined, d);
+};

--- a/packages/data/src/schema/fractional-index/public.ts
+++ b/packages/data/src/schema/fractional-index/public.ts
@@ -1,0 +1,5 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+export { schema } from "./schema.js";
+export { initial } from "./initial.js";
+export { between } from "./between.js";
+export { betweenN } from "./between-n.js";

--- a/packages/data/src/schema/fractional-index/schema.ts
+++ b/packages/data/src/schema/fractional-index/schema.ts
@@ -1,0 +1,7 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Schema } from "../schema.js";
+
+export const schema = {
+    type: 'string',
+    pattern: '^[0-9A-Za-z]+$',
+} as const satisfies Schema;

--- a/packages/data/src/schema/fractional-index/smallest-integer.ts
+++ b/packages/data/src/schema/fractional-index/smallest-integer.ts
@@ -1,0 +1,2 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+export const smallestInteger = "A00000000000000000000000000";

--- a/packages/data/src/schema/fractional-index/validate-integer.ts
+++ b/packages/data/src/schema/fractional-index/validate-integer.ts
@@ -1,0 +1,6 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { integerLength } from "./integer-length.js";
+
+export const validateInteger = (s: string): void => {
+    if (s.length !== integerLength(s.charAt(0))) throw new Error("invalid integer part of order key");
+};

--- a/packages/data/src/schema/fractional-index/validate-order-key.ts
+++ b/packages/data/src/schema/fractional-index/validate-order-key.ts
@@ -1,0 +1,9 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { integerPart } from "./integer-part.js";
+import { smallestInteger } from "./smallest-integer.js";
+
+export const validateOrderKey = (key: string): void => {
+    if (key === smallestInteger) throw new Error("invalid order key");
+    const i = integerPart(key);
+    if (key.slice(i.length).slice(-1) === "0") throw new Error("invalid order key");
+};

--- a/packages/data/src/schema/index.ts
+++ b/packages/data/src/schema/index.ts
@@ -16,3 +16,4 @@ export * from "./boolean/index.js";
 // these are both math types and basic schema types.
 export { F32, I32, U32, F64 } from "../math/index.js";
 export * from "./time/index.js";
+export * from "./fractional-index/fractional-index.js";


### PR DESCRIPTION
## Summary

- Adds `FractionalIndex` to `@adobe/data/schema` as a type-namespace following the project's namespace pattern
- Schema is `{ type: 'string', pattern: '^[0-9A-Za-z]+$' }` — usable directly as an ECS component (e.g. `{ order: FractionalIndex.schema }`)
- Public surface: `FractionalIndex.schema`, `FractionalIndex.initial` (`'a0'`), `FractionalIndex.between(a, b)`, `FractionalIndex.betweenN(a, b, n)`
- Algorithm is a faithful port of the Greenspan/Figma base-62 jitterless fractional-indexing scheme from the horizon codebase, rewritten as plain functions (no classes) per `@adobe/data` conventions
- Private helpers (one file each): `midpoint`, `incrementInteger`, `decrementInteger`, `integerLength`, `integerPart`, `validateInteger`, `validateOrderKey`, `keyBetween`, `digits`, `smallestInteger`

## Test plan

- [x] 76 tests pass covering `midpoint`, `incrementInteger`, `decrementInteger`, `between`, and `betweenN`
- [x] Length-growth properties verified: 100k consecutive appends stay ≤4 chars; 500 head-inserts reach 86 chars; 500-bulk insert between two adjacent keys grows length by ≤2 chars
- [x] All throw conditions verified (invalid head, trailing zero, smallest-integer sentinel, `a >= b`)
- [x] `pnpm build` (TypeScript) passes clean
- [x] `pnpm lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)