### PR TITLE
Add ToAsyncTransactionFn / ToSyncTransactionFn and Plugin.ToTransactionContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.57",
+    "version": "0.9.58",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.57",
+    "version": "0.9.58",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -6,7 +6,7 @@ import { ReadonlyStore, Store } from "../store/index.js";
 import { Entity } from "../entity/entity.js";
 import { EntityReadValues } from "../store/core/index.js";
 import { Observe } from "../../observe/index.js";
-import { TransactionResult } from "./transactional-store/index.js";
+import { TransactionContext, TransactionResult } from "./transactional-store/index.js";
 import { TransactionEnvelope } from "./reconciling/reconciling-database.js";
 import { StringKeyof, RemoveIndex } from "../../types/types.js";
 import { Components } from "../store/components.js";
@@ -235,6 +235,14 @@ export namespace Database {
     export const combine = combinePlugins;
     export type ToDatabase<P extends Database.Plugin> = Database.FromPlugin<P>;
     export type ToStore<P extends Database.Plugin> = Store<FromSchemas<RemoveIndex<P['components']>>, FromSchemas<RemoveIndex<P['resources']>>, RemoveIndex<P['archetypes']>>;
+    /**
+     * The plugin's store as seen *inside a transaction body* — i.e. `ToStore<P>`
+     * plus the `userId` field added by the transaction dispatcher. Use this
+     * when typing helper functions that forward a transaction's store into
+     * another plugin's transaction declaration; `ToStore<P>` is the bare
+     * store type and does not include `userId`.
+     */
+    export type ToTransactionContext<P extends Database.Plugin> = TransactionContext<FromSchemas<RemoveIndex<P['components']>>, FromSchemas<RemoveIndex<P['resources']>>, RemoveIndex<P['archetypes']>>;
     export type ToSystemDatabase<P extends Database.Plugin> = Database.FromPlugin<P> & {
       // Systems are allowed to access the database store directly.
       // This direct access will NOT trigger observable transactions.

--- a/packages/data/src/ecs/store/transaction-functions.ts
+++ b/packages/data/src/ecs/store/transaction-functions.ts
@@ -52,3 +52,30 @@ export type ToTransactionFunctions<T> = {
 
 export type TransactionFunction = (args?: any) => void | Entity;
 export type TransactionFunctions = { readonly [AF: string]: TransactionFunction };
+
+/**
+ * Extracts the `AsyncArgsProvider`-arg overload from a `ToTransactionFunctions`
+ * entry as a single-signature function. TypeScript's structural assignment and
+ * `Parameters` / `ReturnType` see only the *last* overload of an overloaded
+ * function type, which hides the async-provider overload when a transaction is
+ * passed by value (e.g. as a prop). This helper recovers the async-provider
+ * signature without forcing consumers to copy/paste the Input shape.
+ */
+export type ToAsyncTransactionFn<T> = T extends {
+    (arg: AsyncArgsProvider<infer Input>): Promise<infer R>;
+    (arg: any): any;
+}
+    ? (arg: AsyncArgsProvider<Input>) => Promise<R>
+    : never;
+
+/**
+ * Extracts the plain-arg (synchronous) overload from a `ToTransactionFunctions`
+ * entry as a single-signature function. Pairs with `ToAsyncTransactionFn`
+ * for consumers that need to type each call path independently.
+ */
+export type ToSyncTransactionFn<T> = T extends {
+    (arg: AsyncArgsProvider<any>): any;
+    (arg: infer Input): infer R;
+}
+    ? (arg: Input) => R
+    : never;

--- a/packages/data/src/ecs/store/transaction-functions.type-test.ts
+++ b/packages/data/src/ecs/store/transaction-functions.type-test.ts
@@ -17,6 +17,8 @@ import type { Assert } from "../../types/assert.js";
 import type { Equal } from "../../types/equal.js";
 import type {
     AsyncArgsProvider,
+    ToAsyncTransactionFn,
+    ToSyncTransactionFn,
     ToTransactionFunctions,
 } from "./transaction-functions.js";
 import type { Entity } from "../entity/entity.js";
@@ -125,3 +127,30 @@ fns.restart({ unexpected: true });
 
 type AsyncConsumer<T> = (asyncArgs: AsyncArgsProvider<T>) => void;
 const _moveIsAssignable: AsyncConsumer<{ x: number; y: number }> = fns.move;
+
+// ---------------------------------------------------------------------------
+// Green: ToAsyncTransactionFn / ToSyncTransactionFn extract a single overload
+// so that consumers can pass a transaction by value without copy/pasting the
+// Input shape (TS only sees the *last* overload of an overloaded fn type for
+// structural assignment, `Parameters`, and `ReturnType`).
+// ---------------------------------------------------------------------------
+
+type _MoveAsync = Assert<Equal<
+    ToAsyncTransactionFn<SampleFns["move"]>,
+    (arg: AsyncArgsProvider<{ x: number; y: number }>) => Promise<void>
+>>;
+
+type _SpawnAsync = Assert<Equal<
+    ToAsyncTransactionFn<SampleFns["spawn"]>,
+    (arg: AsyncArgsProvider<{ kind: string }>) => Promise<Entity>
+>>;
+
+type _MoveSync = Assert<Equal<
+    ToSyncTransactionFn<SampleFns["move"]>,
+    (arg: { x: number; y: number }) => void
+>>;
+
+type _SpawnSync = Assert<Equal<
+    ToSyncTransactionFn<SampleFns["spawn"]>,
+    (arg: { kind: string }) => Entity
+>>;


### PR DESCRIPTION
## Summary

- Add `ToAsyncTransactionFn<T>` and `ToSyncTransactionFn<T>` in `@adobe/data/ecs` to extract a single overload from a `ToTransactionFunctions` entry. TypeScript only sees the *last* overload for structural assignment / `Parameters` / `ReturnType`, so consumers passing a transaction by value otherwise have to copy/paste the `Input` shape.
- Add `Database.Plugin.ToTransactionContext<P>` next to `ToStore<P>`. `ToTransactionContext` returns the store as seen *inside* a transaction body — `Store<C,R,A> & { userId }` — so consumers typing helper functions that forward a transaction's store into another plugin's transaction declaration no longer have to manually re-add `userId`. `TransactionContext` itself is already on the public `@adobe/data/ecs` surface via `database/index.ts`.
- Bump monorepo packages to 0.9.58.

## Test plan

- [x] `tsc -b` from `packages/data` is clean.
- [x] New compile-time tests in `transaction-functions.type-test.ts` pin both helpers.
- [ ] Consumers replace duplicated `(arg: AsyncArgsProvider<...>) => Promise<...>` prop types with `ToAsyncTransactionFn<...>` and confirm types still flow.
- [ ] Plugins that previously bolted `& { readonly userId: ... }` onto `Database.Plugin.ToStore<P>` switch to `Database.Plugin.ToTransactionContext<P>` and confirm types still flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)