### PR TITLE
fix(cache): break memoize <-> cache barrel circular import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.58",
+    "version": "0.9.59",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.58",
+    "version": "0.9.59",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/cache/functions/memoize.ts
+++ b/packages/data/src/cache/functions/memoize.ts
@@ -4,7 +4,7 @@ import { preventParallelExecution } from "./prevent-parallel-execution.js";
 import { AsyncDataFunction } from "./async-data-function.js";
 
 import { type Data } from "../../data.js";
-import { getDataCache } from "../index.js";
+import { getDataCache } from "../data-cache.js";
 
 /**
  * Uses datacache to store results so we can avoid expensive recomputations of the same input.


### PR DESCRIPTION
## Summary

- `src/cache/functions/memoize.ts` imported `getDataCache` from `"../index.js"` (the cache barrel), which re-exports `"./functions/index.js"`, which re-exports `memoize.ts` — a real circular import chain.
- Switch the import to the source module (`"../data-cache.js"`) to break the cycle.

Reported by a consumer's bundler trace:
```
cache/functions/memoize.js -> cache/index.js -> cache/functions/index.js -> cache/functions/memoize.js
```

## Test plan

- [x] `tsc -b` clean.
- [x] Lint clean on the changed file.
- [ ] Verify bundled consumer no longer reports the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)