### PR TITLE
fix(data): break equals/typed-buffer, aabb, and math/aabb circular imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.59",
+    "version": "0.9.60",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.59",
+    "version": "0.9.60",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/equals.ts
+++ b/packages/data/src/equals.ts
@@ -1,7 +1,13 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
-import { isTypedBuffer } from "./typed-buffer/is-typed-buffer.js";
-import { typedBufferEquals } from "./typed-buffer/typed-buffer-equals.js";
+import type { ReadonlyTypedBuffer } from "./typed-buffer/typed-buffer.js";
+
+// Typed-buffer brand emitted by `TypedBuffer`'s `__brand` field. Duck-typed
+// here (instead of `instanceof TypedBuffer`) so this module has no runtime
+// dependency on `typed-buffer/` — `equals` is the mutual-recursion partner
+// of `typedBufferEquals`, and importing the class would close the cycle
+// `equals → is-typed-buffer → typed-buffer → typed-buffer-equals → equals`.
+const TYPED_BUFFER_BRAND = "TypedBuffer";
 
 /**
  * Very-fast deep equality for JSON-style values.
@@ -33,11 +39,21 @@ export function equals(a: unknown, b: unknown): boolean {
     return true;
   }
 
-  // 3  Typed-buffer fast path
-  const aBuf = isTypedBuffer(a);
-  const bBuf = isTypedBuffer(b);
+  // 3  Typed-buffer fast path. Inlined here (rather than dispatched to
+  // `typedBufferEquals`) so the recursion stays intra-module; see the
+  // brand comment above.
+  const aBuf = (a as { __brand?: string }).__brand === TYPED_BUFFER_BRAND;
+  const bBuf = (b as { __brand?: string }).__brand === TYPED_BUFFER_BRAND;
   if (aBuf || bBuf) {
-    return aBuf && bBuf ? typedBufferEquals(a as any, b as any) : false;
+    if (!aBuf || !bBuf) return false;
+    const ab = a as ReadonlyTypedBuffer<unknown>;
+    const bb = b as ReadonlyTypedBuffer<unknown>;
+    if (ab.type !== bb.type || ab.capacity !== bb.capacity) return false;
+    if (!equals(ab.schema, bb.schema)) return false;
+    for (let i = 0; i < ab.capacity; i++) {
+      if (!equals(ab.get(i), bb.get(i))) return false;
+    }
+    return true;
   }
 
   // 4  Plain objects

--- a/packages/data/src/math/aabb/face/from-position.ts
+++ b/packages/data/src/math/aabb/face/from-position.ts
@@ -1,7 +1,9 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
 import type { Vec3 } from "../../vec3/index.js";
-import { Aabb } from "../index.js";
+import type { Aabb } from "../index.js";
+import { center } from "../center.js";
+import { unit } from "../unit.js";
 import type { Face } from "./face.js";
 import { NEG_X } from "./neg-x.js";
 import { NEG_Y } from "./neg-y.js";
@@ -15,8 +17,8 @@ import { POS_Z } from "./pos-z.js";
  * @param position World position of the sample point
  * @param aabb Bounds used to compute the box center (defaults to unit cube)
  */
-export const fromPosition = (position: Vec3, aabb: Aabb = Aabb.unit): Face => {
-    const aabbCenter = Aabb.center(aabb);
+export const fromPosition = (position: Vec3, aabb: Aabb = unit): Face => {
+    const aabbCenter = center(aabb);
     const localPos = [
         position[0] - aabbCenter[0],
         position[1] - aabbCenter[1],

--- a/packages/data/src/math/aabb/schema.ts
+++ b/packages/data/src/math/aabb/schema.ts
@@ -1,7 +1,7 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
 import { Schema } from "../../schema/index.js";
-import { Vec3 } from "../index.js";
+import { Vec3 } from "../vec3/index.js";
 
 export const schema = {
     type: 'object',


### PR DESCRIPTION
## Summary

Three circular-import cycles flagged by consumer bundlers, no public API change:

1. **`equals.ts` ↔ `typed-buffer/typed-buffer-equals.ts`** — mutually recursive (each calls the other for deep equality). Inline the typed-buffer fast path into `equals.ts` and switch detection to a duck-typed `__brand` check + `import type` of `ReadonlyTypedBuffer`. `TypedBuffer.equals` (public surface via the class static) still points at `typedBufferEquals` unchanged.
2. **`math/aabb/index` → `public` → `face/face` → `face/public` → `face/from-position` → `aabb/index`** — `from-position.ts` imported the `Aabb` namespace value from the aabb barrel. Switch to `import type { Aabb }` + direct `center` / `unit` imports per the namespace rule.
3. **`math/index` → `aabb/index` → `public` → `schema` → `math/index`** (and the longer `…layout → schema → math/index` variant) — `aabb/schema.ts` imported `Vec3` from the math barrel. Switch to `../vec3/index.js` directly.

## Test plan

- [x] `tsc -b` clean.
- [x] All targeted tests pass (`src/equals.test.ts`, `typed-buffer-equals.test.ts`, `src/math/aabb/**`) — 176 tests, 22 files.
- [ ] Consumer bundler no longer reports the three cycles above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)