### PR TITLE
feat(ecs): pluggable concurrency strategies for database

### DIFF
--- a/packages/data-p2p-tictactoe/src/state/negotiation-controller.ts
+++ b/packages/data-p2p-tictactoe/src/state/negotiation-controller.ts
@@ -4,7 +4,7 @@
 // construction. Pumps results into a negotiation database via transactions
 // so the UI can render purely from observable state.
 
-import { Database } from "@adobe/data/ecs";
+import { Database, createRebaseReplayConcurrency } from "@adobe/data/ecs";
 import { createSyncServer, createSyncService, createLoopbackTransport, type SyncService } from "@adobe/data-sync";
 import { startHostSignaling, startJoinerSignaling, type HostConnection, type JoinerConnection } from "../signaling.js";
 import { createRenegotiator, type Renegotiator } from "../renegotiator.js";
@@ -161,7 +161,7 @@ export const createNegotiationController = (
     ) => {
         if (!gameDb) {
             log(`creating game DB for userId=${userId}`);
-            gameDb = Database.create(config.gamePlugin, { sync: { userId } });
+            gameDb = Database.create(config.gamePlugin, { concurrency: createRebaseReplayConcurrency(userId) });
         }
         wireSync();
         db.transactions.setGameDb({ gameDb });

--- a/packages/data-sync/src/create-sync-service.ts
+++ b/packages/data-sync/src/create-sync-service.ts
@@ -9,11 +9,11 @@ import type { ClientTransport, ServerMessage } from "./transport.js";
 export interface SyncServiceOptions {
     /**
      * The database to wire into the sync layer. Must have been created with
-     * `Database.create(plugin, { sync: { userId } })` where `userId` is
-     * unique per peer — the reconciler's transient queue uses
-     * `(userId, id)` as its compound key to keep concurrent peers from
-     * colliding, and the wrapper's deferred-commit semantics are required
-     * for cross-peer entity-id determinism.
+     * `createRebaseReplayConcurrency(userId)` as its concurrency strategy,
+     * where `userId` is unique per peer — the reconciler's transient queue
+     * uses `(userId, id)` as its compound key to keep concurrent peers from
+     * colliding, and the deferred-commit semantics are required for cross-peer
+     * entity-id determinism.
      */
     readonly database: Database<any, any, any, any>;
     /** Transport connecting this peer to the sync server. */
@@ -109,7 +109,9 @@ export interface SyncService {
  *
  * @example
  * ```ts
- * const db = Database.create(myPlugin, { sync: { userId: crypto.randomUUID() } });
+ * const db = Database.create(myPlugin, {
+ *     concurrency: createRebaseReplayConcurrency(crypto.randomUUID()),
+ * });
  * const sync = createSyncService({ database: db, transport: ws });
  *
  * db.transactions.spawnUnit({ x: 0, y: 0, hp: 100 });
@@ -131,9 +133,9 @@ export const createSyncService = (options: SyncServiceOptions): SyncService => {
     } = options;
     const log = logger ?? (() => undefined);
 
-    if (database.sync === undefined) {
+    if (!database.concurrency.deferredCommit || database.concurrency.userId === undefined) {
         throw new Error(
-            "createSyncService: database was not created in sync mode. Pass `sync: { userId }` to `Database.create`.",
+            "createSyncService: database must use createRebaseReplayConcurrency(userId) as its concurrency strategy.",
         );
     }
 

--- a/packages/data-sync/src/keepalive.test.ts
+++ b/packages/data-sync/src/keepalive.test.ts
@@ -8,7 +8,7 @@
 // listeners, which higher layers wire to a reconnect flow.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Database } from "@adobe/data/ecs";
+import { Database, createRebaseReplayConcurrency } from "@adobe/data/ecs";
 import type { ClientMessage, ServerMessage } from "./transport.js";
 import { createLoopbackTransport } from "./loopback-transport.js";
 import { createSyncServer } from "./create-sync-server.js";
@@ -21,7 +21,7 @@ const plugin = Database.Plugin.create({
     transactions: {},
 });
 
-const makeDb = (userId: string) => Database.create(plugin, { sync: { userId } });
+const makeDb = (userId: string) => Database.create(plugin, { concurrency: createRebaseReplayConcurrency(userId) });
 
 describe("sync keep-alive (ping/pong)", () => {
     beforeEach(() => {

--- a/packages/data-sync/src/sync.reconnect.test.ts
+++ b/packages/data-sync/src/sync.reconnect.test.ts
@@ -11,7 +11,7 @@
 //   6. End-to-end: new server (session mismatch) → reset + full replay.
 
 import { describe, it, expect, vi } from "vitest";
-import { Database } from "@adobe/data/ecs";
+import { Database, createRebaseReplayConcurrency } from "@adobe/data/ecs";
 import { createLoopbackTransport } from "./loopback-transport.js";
 import { createSyncServer } from "./create-sync-server.js";
 import { createSyncService } from "./create-sync-service.js";
@@ -39,7 +39,7 @@ const plugin = Database.Plugin.create({
     },
 });
 
-const makeDb = (userId: string) => Database.create(plugin, { sync: { userId } });
+const makeDb = (userId: string) => Database.create(plugin, { concurrency: createRebaseReplayConcurrency(userId) });
 const entityCount = (db: ReturnType<typeof makeDb>) => db.select(["x", "label"]).length;
 const labels = (db: ReturnType<typeof makeDb>) =>
     db.select(["label"]).map(e => db.read(e)?.label as string).sort();

--- a/packages/data-sync/src/sync.test.ts
+++ b/packages/data-sync/src/sync.test.ts
@@ -8,7 +8,7 @@
 // envelopes transparently.
 
 import { describe, it, expect } from "vitest";
-import { Database } from "@adobe/data/ecs";
+import { Database, createRebaseReplayConcurrency } from "@adobe/data/ecs";
 import { createLoopbackTransport } from "./loopback-transport.js";
 import { createSyncServer } from "./create-sync-server.js";
 import { createSyncService } from "./create-sync-service.js";
@@ -49,7 +49,7 @@ const plugin = Database.Plugin.create({
     },
 });
 
-const makeDb = (userId: string) => Database.create(plugin, { sync: { userId } });
+const makeDb = (userId: string) => Database.create(plugin, { concurrency: createRebaseReplayConcurrency(userId) });
 
 const snap = (db: ReturnType<typeof makeDb>) =>
     db.select(["x", "y", "label"])

--- a/packages/data/src/ecs/archetype/archetype.ts
+++ b/packages/data/src/ecs/archetype/archetype.ts
@@ -26,13 +26,20 @@ interface BaseArchetype {
 }
 export interface ReadonlyArchetype<C extends RequiredComponents> extends BaseArchetype, ReadonlyTable<C> {
     readonly components: ComponentSet<StringKeyof<C>>;
-    toData: () => unknown
+    /**
+     * Serialize the archetype. When `copy` is true each column buffer is
+     * detached (`.copy()`) so the snapshot survives later mutation of the live
+     * archetype; otherwise the snapshot references the live column buffers
+     * (faster, but only valid until the next mutation).
+     */
+    toData: (copy?: boolean) => unknown
 }
 
 export interface Archetype<C extends RequiredComponents = RequiredComponents> extends BaseArchetype, Table<C> {
     readonly components: ComponentSet<StringKeyof<C>>;
     insert: <T extends EntityInsertValues<C>>(rowData: Exact<EntityInsertValues<C>, T>) => Entity;
-    toData: () => unknown
+    /** See {@link ReadonlyArchetype.toData}. */
+    toData: (copy?: boolean) => unknown
     fromData: (data: unknown) => void
 }
 

--- a/packages/data/src/ecs/archetype/create-archetype.ts
+++ b/packages/data/src/ecs/archetype/create-archetype.ts
@@ -192,8 +192,13 @@ export const createArchetype = <C extends { id: typeof Entity.schema }>(
         ...table,
         components: componentSet as Set<StringKeyof<C>>,
         insert: createEntity,
-        toData: () => ({
-            columns: archetype.columns,
+        toData: (copy = false) => ({
+            columns: copy
+                ? Object.fromEntries(
+                    Object.entries(archetype.columns as Record<string, { copy: () => unknown }>)
+                        .map(([name, column]) => [name, column.copy()]),
+                )
+                : archetype.columns,
             rowCount: archetype.rowCount,
             rowCapacity: archetype.rowCapacity,
         }),

--- a/packages/data/src/ecs/database/concurrency/README.md
+++ b/packages/data/src/ecs/database/concurrency/README.md
@@ -150,9 +150,3 @@ immediately).
 - `db.concurrency` exposes the live strategy. `data-sync` reads
   `concurrency.deferredCommit` and `concurrency.userId` to confirm a database is
   in a sync-capable mode.
-- For a fundamentally different engine (CRDT, OT, authoritative server), prefer a
-  *new strategy* over an outer `(db) => db` decorator: concurrency must
-  participate before transactions are wrapped and needs `execute`/`getTransaction`,
-  neither of which is on the public surface. Outer decorators are the right tool
-  only for concerns that ride entirely on the finished public API (logging,
-  metrics, tracing).

--- a/packages/data/src/ecs/database/concurrency/README.md
+++ b/packages/data/src/ecs/database/concurrency/README.md
@@ -92,8 +92,8 @@ The two built-ins are the reference implementations and bracket the design space
   preserving). Shares `createRebaseReplayApplier`.
 - **`roll-forward`** — replays pending edits by re-applying captured post-image
   tuples (`applyOperations(t, entry.redo)`), not by re-running their functions
-  (deterministic w.r.t. base drift). A client-side model of the LES coediting
-  design; present mainly to prove the seam.
+  (deterministic w.r.t. base drift). A client-side collaborative-editing model;
+  present mainly to prove the seam.
 
 ## Invariants — read before implementing
 

--- a/packages/data/src/ecs/database/concurrency/README.md
+++ b/packages/data/src/ecs/database/concurrency/README.md
@@ -1,0 +1,158 @@
+# Concurrency strategies
+
+A `ConcurrencyStrategy` owns how a transaction mutates the store: when a local
+edit applies, whether it waits for a server echo, and how inbound/echoed
+envelopes are reconciled against in-flight local state. It is the single seam
+through which the database's *consistency model* is swapped — everything else
+(transaction wrapping, observers, indexes, the typed public surface) is built by
+the library around whatever strategy you supply.
+
+```ts
+const db = createDatabase(plugin, { concurrency: createRebaseReplayConcurrency(userId) });
+```
+
+Omitting `concurrency` selects `createImmediateConcurrency()`.
+
+## The contract
+
+```ts
+type ConcurrencyStrategyFactory = (
+  execute:        (fn, opts?: { transient?: boolean; userId?: Id }) => TransactionResult,
+  getTransaction: (name: string) => TransactionFn | undefined,
+) => ConcurrencyStrategy;
+
+interface ConcurrencyStrategy {
+  deferredCommit: boolean;          // read ONCE at construction by the dispatcher
+  userId?: number | string;         // stamped on outbound envelopes; surfaced as db.concurrency.userId
+  apply(envelope): TransactionResult | undefined;
+  cancel(id, userId?): void;
+  onReset(): void;
+  onBeforeToData?(): void;          // see "Serialization"
+  onAfterToData?(): void;
+  onAfterFromData?(): void;
+}
+```
+
+The factory is invoked once during construction. You get two type-erased
+capabilities below the public API:
+
+- **`execute(fn, opts)`** runs `fn(ctx)` as one atomic transaction, fires
+  observers, and returns a `TransactionResult` whose `redo`/`undo` are the
+  post-image / inverse data tuples. `opts.transient` only tags the result as
+  intermediate; it does *not* change durability. `opts.userId` is threaded into
+  `ctx.userId`.
+- **`getTransaction(name)`** resolves a registered transaction function. It is
+  **lazy** — names are registered by `extend()` *after* the strategy is built,
+  so resolve at call time, never cache at construction.
+
+### Envelopes
+
+`apply` is the one entry point for both locally-initiated transactions (from the
+dispatcher) and inbound ones (`db.apply` from a sync service). The `time` sign is
+the discriminator:
+
+| `time` | meaning        |
+|--------|----------------|
+| `< 0`  | transient (optimistic / intermediate) |
+| `> 0`  | committed (authoritative) |
+| `= 0`  | cancel the `(userId, id)` entry |
+
+`deferredCommit` decides how the dispatcher emits a user's `commit` intent: when
+`true`, commits are applied locally as transients (`time < 0`) and you promote
+them when the authoritative echo (`time > 0`) arrives; when `false`, commits
+apply immediately (`time > 0`). The `(userId, id)` pair is the compound identity
+of an in-flight entry across peers.
+
+## Writing one
+
+```ts
+export const createMyConcurrency = (userId): ConcurrencyStrategyFactory =>
+  (execute, getTransaction) => {
+    const run = (env) => {
+      const fn = getTransaction(env.name);
+      if (!fn) throw new Error(`Unknown transaction: ${env.name}`);
+      return execute(t => fn(t, env.args), { transient: env.time < 0, userId: env.userId });
+    };
+    return {
+      deferredCommit: true,
+      userId,
+      apply(env) { /* your reconciliation; call run(env) / replay tuples */ },
+      cancel(id, uid) { /* roll back the (uid,id) entry */ },
+      onReset() { /* drop any pending buffer */ },
+    };
+  };
+```
+
+The two built-ins are the reference implementations and bracket the design space:
+
+- **`immediate`** — no pending buffer, commits land directly. Per-transaction
+  transient rollback only (for async-generator yields). Use as the base for an
+  external wrapper that runs its own reconciliation.
+- **`rebase-replay`** — re-executes pending transactions on rebase (intent
+  preserving). Shares `createRebaseReplayApplier`.
+- **`roll-forward`** — replays pending edits by re-applying captured post-image
+  tuples (`applyOperations(t, entry.redo)`), not by re-running their functions
+  (deterministic w.r.t. base drift). A client-side model of the LES coediting
+  design; present mainly to prove the seam.
+
+## Invariants — read before implementing
+
+1. **Roll back in reverse stack order, never mid-stack.** Entity-id allocation
+   draws from a freelist. Undoing a non-top entry while lower entries are still
+   applied corrupts the freelist. The rebase shape is always: roll back *all*
+   transients newest→oldest → apply the committed envelope → replay survivors
+   oldest→newest.
+
+2. **Cross-peer id determinism requires the rebase.** Applying a committed
+   envelope on a clean (fully rolled-back) base guarantees every peer takes the
+   same freelist/`nextIndex` snapshot at that point, so allocations converge.
+   Apply a commit *on top of* pending transients and ids diverge across peers.
+   `immediate` deliberately forgoes this (single-writer / externally-reconciled).
+
+3. **Do not fire `observe.envelopes`.** The dispatcher owns outbound
+   notification, intent tagging, the `nextTransactionId` counter, no-op
+   suppression, and `userId` stamping. `apply` is purely the store-mutation side.
+
+4. **`apply` must be a deterministic function of `(store state, envelope)`** for
+   any strategy that targets convergence. No wall-clock, no RNG, no peer-local
+   ambient state inside the transaction path.
+
+5. **Replay must reproduce identical effects.** Re-execution (rebase-replay) is
+   intent-preserving but recomputes against the new base; tuple roll-forward is
+   base-invariant but freezes the original post-image. Pick deliberately — they
+   diverge exactly when a transaction reads state it also writes.
+
+6. **`deferredCommit` is immutable post-construction.** It is captured once by
+   the dispatcher; you cannot flip modes at runtime — build a new database.
+
+## Serialization
+
+`db.toData()` rolls back, serializes, and replays so a snapshot excludes
+in-flight transients. The snapshot is otherwise backed by **live** store buffers,
+so the replay would corrupt it — therefore, when `onAfterToData` is present, the
+database serializes a **detached copy** (`store.toData(true)`, which clones
+columns and the entity table) between `onBeforeToData` and `onAfterToData`. If
+your strategy keeps a pending buffer:
+
+- `onBeforeToData` → roll all transients back (committed-only state),
+- `onAfterToData` → replay them,
+- `onAfterFromData` → replay them after a load.
+
+Omit all three if you have no pending state; the database then returns the faster
+live-reference snapshot, valid only until the next mutation (serialize it
+immediately).
+
+## Notes
+
+- The seam is intentionally type-erased (`any`/`unknown`). Strategies operate
+  below the typed `Database` surface; the library reconstructs full generic types
+  around your output. Don't try to make the strategy generic.
+- `db.concurrency` exposes the live strategy. `data-sync` reads
+  `concurrency.deferredCommit` and `concurrency.userId` to confirm a database is
+  in a sync-capable mode.
+- For a fundamentally different engine (CRDT, OT, authoritative server), prefer a
+  *new strategy* over an outer `(db) => db` decorator: concurrency must
+  participate before transactions are wrapped and needs `execute`/`getTransaction`,
+  neither of which is on the public surface. Outer decorators are the right tool
+  only for concerns that ride entirely on the finished public API (logging,
+  metrics, tracing).

--- a/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
+++ b/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
@@ -15,7 +15,7 @@ import type { TransactionEnvelope } from "../reconciling/reconciling-database.js
  *
  *   - `createImmediateConcurrency()` — commits apply immediately, no
  *     rollback queue. Use this as the base database for external wrappers
- *     (e.g. a coediting layer that manages its own replay buffer).
+ *     (e.g. a collaborative-editing layer that manages its own replay buffer).
  *
  *   - `createRebaseReplayConcurrency(userId)` — commits apply locally as
  *     transients and wait for the sync server's echoed committed envelope to

--- a/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
+++ b/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
@@ -59,10 +59,10 @@ export interface ConcurrencyStrategy {
      * Strategies with a transient queue should roll back transients here so
      * the snapshot contains only committed state.
      *
-     * KNOWN BUG: `db.toData()` returns live buffer references, and
-     * `onAfterToData` replay mutates them before the caller serializes — so
-     * this rollback does not actually keep transients out of a persisted
-     * snapshot today. See `Database.toData()` for the full writeup.
+     * When this hook (together with `onAfterToData`) is present, `db.toData()`
+     * serializes a detached copy of the store between the two hooks, so the
+     * `onAfterToData` replay cannot corrupt the returned snapshot. See
+     * `Database.toData()`.
      */
     readonly onBeforeToData?: () => void;
 

--- a/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
+++ b/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
@@ -1,0 +1,97 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import type { Entity } from "../../entity/entity.js";
+import type { TransactionContext, TransactionResult } from "../transactional-store/index.js";
+import type { TransactionEnvelope } from "../reconciling/reconciling-database.js";
+
+/**
+ * A function that executes a transaction against the store, fires observers,
+ * and returns the mutation record. This is the observed database's `execute`.
+ */
+export type ConcurrencyExecuteFn = (
+    fn: (ctx: TransactionContext<any, any, any>) => void | Entity,
+    options?: { transient?: boolean; userId?: number | string },
+) => TransactionResult<unknown>;
+
+/**
+ * A function that looks up a registered transaction function by name.
+ * Returns undefined when the name is not yet registered.
+ */
+export type ConcurrencyGetTransactionFn = (
+    name: string,
+) => ((ctx: TransactionContext<any, any, any>, args: unknown) => void | Entity) | undefined;
+
+/**
+ * The interface every concurrency strategy must satisfy.
+ *
+ * A strategy encapsulates all decisions about how locally-initiated
+ * transactions are applied and how inbound envelopes (from a sync service
+ * or another local source) are reconciled against the current store state.
+ *
+ * Two built-in strategies are provided:
+ *
+ *   - `createImmediateConcurrency()` — commits apply immediately, no
+ *     rollback queue. Use this as the base database for external wrappers
+ *     (e.g. a coediting layer that manages its own replay buffer).
+ *
+ *   - `createRebaseReplayConcurrency(userId)` — commits apply locally as
+ *     transients and wait for the sync server's echoed committed envelope to
+ *     promote them. Full rollback-and-replay queue, cross-peer id-determinism.
+ */
+export interface ConcurrencyStrategy {
+    /**
+     * When true, the dispatcher applies "commit" intents as transients
+     * (negative time) and waits for a server echo to promote them.
+     * When false, commits apply immediately with positive time.
+     */
+    readonly deferredCommit: boolean;
+
+    /**
+     * Peer/session identifier stamped on every outbound envelope.
+     * Required for strategies that participate in a multi-peer sync protocol.
+     */
+    readonly userId?: number | string;
+
+    /**
+     * Process a transaction envelope. Called by the dispatcher for each
+     * locally-initiated transaction and by sync services for inbound commits.
+     * Does NOT fire `observe.envelopes` (that is the dispatcher's job).
+     */
+    readonly apply: (envelope: TransactionEnvelope) => TransactionResult<unknown> | undefined;
+
+    /**
+     * Cancel a pending transient by compound (userId, id) key.
+     * No-op for strategies that have no transient queue.
+     */
+    readonly cancel: (id: number, userId?: number | string) => void;
+
+    /**
+     * Called by `db.reset()` before the store is cleared.
+     * Strategies with a transient queue should clear it here.
+     */
+    readonly onReset: () => void;
+
+    /**
+     * If provided, wraps `db.toData()`. The strategy is responsible for
+     * calling `base()` and handling rollback/replay around it.
+     * Omit when the strategy has no transient state that needs to be
+     * excluded from the serialized snapshot.
+     */
+    readonly toData?: (base: () => unknown) => unknown;
+
+    /**
+     * If provided, wraps `db.fromData()`. The strategy is responsible for
+     * calling `base(data)` and handling replay after the load.
+     * Omit when the strategy has no transient queue to replay.
+     */
+    readonly fromData?: (base: (data: unknown) => void, data: unknown) => void;
+}
+
+/**
+ * Factory that creates a `ConcurrencyStrategy` bound to the given execute
+ * and transaction-lookup functions. Called once per database at construction.
+ */
+export type ConcurrencyStrategyFactory = (
+    execute: ConcurrencyExecuteFn,
+    getTransaction: ConcurrencyGetTransactionFn,
+) => ConcurrencyStrategy;

--- a/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
+++ b/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
@@ -5,23 +5,6 @@ import type { TransactionContext, TransactionResult } from "../transactional-sto
 import type { TransactionEnvelope } from "../reconciling/reconciling-database.js";
 
 /**
- * A function that executes a transaction against the store, fires observers,
- * and returns the mutation record. This is the observed database's `execute`.
- */
-export type ConcurrencyExecuteFn = (
-    fn: (ctx: TransactionContext<any, any, any>) => void | Entity,
-    options?: { transient?: boolean; userId?: number | string },
-) => TransactionResult<unknown>;
-
-/**
- * A function that looks up a registered transaction function by name.
- * Returns undefined when the name is not yet registered.
- */
-export type ConcurrencyGetTransactionFn = (
-    name: string,
-) => ((ctx: TransactionContext<any, any, any>, args: unknown) => void | Entity) | undefined;
-
-/**
  * The interface every concurrency strategy must satisfy.
  *
  * A strategy encapsulates all decisions about how locally-initiated
@@ -72,26 +55,43 @@ export interface ConcurrencyStrategy {
     readonly onReset: () => void;
 
     /**
-     * If provided, wraps `db.toData()`. The strategy is responsible for
-     * calling `base()` and handling rollback/replay around it.
-     * Omit when the strategy has no transient state that needs to be
-     * excluded from the serialized snapshot.
+     * Called immediately before `db.toData()` serializes the store.
+     * Strategies with a transient queue should roll back transients here so
+     * the snapshot contains only committed state.
      */
-    readonly toData?: (base: () => unknown) => unknown;
+    readonly onBeforeToData?: () => void;
 
     /**
-     * If provided, wraps `db.fromData()`. The strategy is responsible for
-     * calling `base(data)` and handling replay after the load.
-     * Omit when the strategy has no transient queue to replay.
+     * Called immediately after `db.toData()` serializes the store.
+     * Strategies that roll back in `onBeforeToData` should replay here to
+     * restore the in-progress transient state.
      */
-    readonly fromData?: (base: (data: unknown) => void, data: unknown) => void;
+    readonly onAfterToData?: () => void;
+
+    /**
+     * Called immediately after `db.fromData()` loads a snapshot into the
+     * store. Strategies with a transient queue should replay pending
+     * transients here so in-progress work is visible after a data load.
+     */
+    readonly onAfterFromData?: () => void;
 }
 
 /**
  * Factory that creates a `ConcurrencyStrategy` bound to the given execute
  * and transaction-lookup functions. Called once per database at construction.
+ *
+ * `execute` is the observed database's execute — it applies a transaction,
+ * fires observers, and returns the mutation record.
+ *
+ * `getTransaction` looks up a registered transaction function by name,
+ * returning undefined when the name has not yet been registered via extend.
  */
 export type ConcurrencyStrategyFactory = (
-    execute: ConcurrencyExecuteFn,
-    getTransaction: ConcurrencyGetTransactionFn,
+    execute: (
+        fn: (ctx: TransactionContext<any, any, any>) => void | Entity,
+        options?: { transient?: boolean; userId?: number | string },
+    ) => TransactionResult<unknown>,
+    getTransaction: (
+        name: string,
+    ) => ((ctx: TransactionContext<any, any, any>, args: unknown) => void | Entity) | undefined,
 ) => ConcurrencyStrategy;

--- a/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
+++ b/packages/data/src/ecs/database/concurrency/concurrency-strategy.ts
@@ -58,6 +58,11 @@ export interface ConcurrencyStrategy {
      * Called immediately before `db.toData()` serializes the store.
      * Strategies with a transient queue should roll back transients here so
      * the snapshot contains only committed state.
+     *
+     * KNOWN BUG: `db.toData()` returns live buffer references, and
+     * `onAfterToData` replay mutates them before the caller serializes — so
+     * this rollback does not actually keep transients out of a persisted
+     * snapshot today. See `Database.toData()` for the full writeup.
      */
     readonly onBeforeToData?: () => void;
 

--- a/packages/data/src/ecs/database/concurrency/immediate-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/immediate-concurrency.ts
@@ -16,7 +16,8 @@ import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurre
  *     applied directly without rolling back other pending transients. This
  *     means entity-id allocation is NOT deterministic across peers under
  *     concurrent edits — use this only when there is a single writer or
- *     when an external layer manages replay (e.g. a coediting wrapper).
+ *     when an external layer manages replay (e.g. a collaborative-editing
+ *     wrapper).
  *   - Async generator transients are still supported: each yield applies
  *     the intermediate state immediately and rolls it back when the next
  *     yield or the final commit arrives. Cancel rolls back the last

--- a/packages/data/src/ecs/database/concurrency/immediate-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/immediate-concurrency.ts
@@ -1,0 +1,80 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { applyOperations } from "../transactional-store/apply-operations.js";
+import type { TransactionResult } from "../transactional-store/index.js";
+import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
+
+/**
+ * Lighter-weight concurrency strategy that applies commits and transients
+ * immediately with no global rollback-and-replay cycle.
+ *
+ * Key differences from {@link createRebaseReplayConcurrency}:
+ *
+ *   - No deferred-commit mode — `db.transactions.X(args)` commits
+ *     synchronously with positive time.
+ *   - No global rebase: when an inbound committed envelope arrives, it is
+ *     applied directly without rolling back other pending transients. This
+ *     means entity-id allocation is NOT deterministic across peers under
+ *     concurrent edits — use this only when there is a single writer or
+ *     when an external layer manages replay (e.g. a coediting wrapper).
+ *   - Async generator transients are still supported: each yield applies
+ *     the intermediate state immediately and rolls it back when the next
+ *     yield or the final commit arrives. Cancel rolls back the last
+ *     applied transient for that transaction. Transients from different
+ *     concurrent transactions do NOT interact (no cross-transaction rebase).
+ */
+export const createImmediateConcurrency = (): ConcurrencyStrategyFactory =>
+    (execute, getTransaction): ConcurrencyStrategy => {
+        // Per-transaction store of the last-applied transient result, keyed
+        // by compound `"userId:id"`. Used to roll back a transient when a
+        // newer transient, commit, or cancel arrives for the same transaction.
+        const pending = new Map<string, TransactionResult<unknown>>();
+
+        const key = (id: number, userId?: number | string) => `${userId}:${id}`;
+
+        const rollbackPending = (id: number, userId?: number | string) => {
+            const k = key(id, userId);
+            const prior = pending.get(k);
+            if (prior) {
+                execute(t => applyOperations(t, prior.undo), { transient: true, userId: undefined });
+                pending.delete(k);
+            }
+        };
+
+        return {
+            deferredCommit: false,
+            apply(envelope) {
+                const { id, userId, time, args } = envelope;
+
+                if (time === 0) {
+                    rollbackPending(id, userId);
+                    return undefined;
+                }
+
+                if (time < 0) {
+                    // Roll back the previous transient for this transaction (if any),
+                    // then apply the new one. No interaction with other transactions.
+                    rollbackPending(id, userId);
+                    const fn = getTransaction(envelope.name);
+                    if (!fn) throw new Error(`Unknown transaction: ${envelope.name}`);
+                    const result = execute(t => fn(t, args), { transient: true, userId });
+                    const isNoOp = result.redo.length === 0 && result.undo.length === 0;
+                    if (!isNoOp) pending.set(key(id, userId), result);
+                    return result;
+                }
+
+                // Positive time: commit. Roll back any pending transient for this
+                // transaction, then apply the committed state.
+                rollbackPending(id, userId);
+                const fn = getTransaction(envelope.name);
+                if (!fn) throw new Error(`Unknown transaction: ${envelope.name}`);
+                return execute(t => fn(t, args), { transient: false, userId });
+            },
+            cancel(id, userId) {
+                rollbackPending(id, userId);
+            },
+            onReset() {
+                pending.clear();
+            },
+        };
+    };

--- a/packages/data/src/ecs/database/concurrency/index.ts
+++ b/packages/data/src/ecs/database/concurrency/index.ts
@@ -3,3 +3,4 @@
 export type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
 export { createImmediateConcurrency } from "./immediate-concurrency.js";
 export { createRebaseReplayConcurrency } from "./rebase-replay-concurrency.js";
+export { createRollForwardConcurrency } from "./roll-forward-concurrency.js";

--- a/packages/data/src/ecs/database/concurrency/index.ts
+++ b/packages/data/src/ecs/database/concurrency/index.ts
@@ -1,5 +1,5 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
-export type { ConcurrencyStrategy, ConcurrencyStrategyFactory, ConcurrencyExecuteFn, ConcurrencyGetTransactionFn } from "./concurrency-strategy.js";
+export type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
 export { createImmediateConcurrency } from "./immediate-concurrency.js";
 export { createRebaseReplayConcurrency } from "./rebase-replay-concurrency.js";

--- a/packages/data/src/ecs/database/concurrency/index.ts
+++ b/packages/data/src/ecs/database/concurrency/index.ts
@@ -1,0 +1,5 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+export type { ConcurrencyStrategy, ConcurrencyStrategyFactory, ConcurrencyExecuteFn, ConcurrencyGetTransactionFn } from "./concurrency-strategy.js";
+export { createImmediateConcurrency } from "./immediate-concurrency.js";
+export { createRebaseReplayConcurrency } from "./rebase-replay-concurrency.js";

--- a/packages/data/src/ecs/database/concurrency/rebase-replay-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/rebase-replay-concurrency.ts
@@ -15,22 +15,23 @@ import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurre
  *   - Every outbound envelope is stamped with `userId` so the reconciler's
  *     compound `(userId, id)` key keeps concurrent peers' id counters from
  *     colliding.
- *   - `toData` / `fromData` roll back and replay the transient queue around
- *     serialisation so snapshots always contain only committed state.
+ *   - `onBeforeToData` / `onAfterToData` roll back and replay the transient
+ *     queue around serialisation so snapshots always contain only committed state.
  *
  * @param userId Stable peer/session identifier unique across all peers
  *   sharing the same sync server.
  */
 export const createRebaseReplayConcurrency = (userId: number | string): ConcurrencyStrategyFactory =>
-    (execute, getTransaction): ConcurrencyStrategy => {
-        const applier = createRebaseReplayApplier(execute, getTransaction);
+    (...args): ConcurrencyStrategy => {
+        const applier = createRebaseReplayApplier(...args);
         return {
             deferredCommit: true,
             userId,
             apply: applier.apply,
             cancel: applier.cancel,
             onReset: applier.onReset,
-            toData: applier.toData,
-            fromData: applier.fromData,
+            onBeforeToData: applier.rollbackAllTransients,
+            onAfterToData: applier.replayAllTransients,
+            onAfterFromData: applier.replayAllTransients,
         };
     };

--- a/packages/data/src/ecs/database/concurrency/rebase-replay-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/rebase-replay-concurrency.ts
@@ -1,0 +1,36 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { createRebaseReplayApplier } from "../reconciling/create-rebase-replay-applier.js";
+import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
+
+/**
+ * Concurrency strategy that implements the optimistic rebase-replay protocol
+ * required for multi-peer synchronisation.
+ *
+ * Behaviour:
+ *   - Local "commit" intents are applied as transients (negative time) and
+ *     wait for the sync server's echoed committed envelope to promote them
+ *     via rollback-and-replay. This is required for cross-peer entity-id
+ *     determinism under concurrent edits.
+ *   - Every outbound envelope is stamped with `userId` so the reconciler's
+ *     compound `(userId, id)` key keeps concurrent peers' id counters from
+ *     colliding.
+ *   - `toData` / `fromData` roll back and replay the transient queue around
+ *     serialisation so snapshots always contain only committed state.
+ *
+ * @param userId Stable peer/session identifier unique across all peers
+ *   sharing the same sync server.
+ */
+export const createRebaseReplayConcurrency = (userId: number | string): ConcurrencyStrategyFactory =>
+    (execute, getTransaction): ConcurrencyStrategy => {
+        const applier = createRebaseReplayApplier(execute, getTransaction);
+        return {
+            deferredCommit: true,
+            userId,
+            apply: applier.apply,
+            cancel: applier.cancel,
+            onReset: applier.onReset,
+            toData: applier.toData,
+            fromData: applier.fromData,
+        };
+    };

--- a/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
+++ b/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
@@ -1,9 +1,9 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 //
 // Verifies the pluggable-concurrency seam by running a client-side
-// implementation of the LES coediting model (roll-forward replay) through the
-// public `createDatabase` API, and contrasting it with the built-in
-// rebase-replay strategy on an identical scenario.
+// roll-forward replay strategy through the public `createDatabase` API, and
+// contrasting it with the built-in rebase-replay strategy on an identical
+// scenario.
 
 import { describe, it, expect, vi } from "vitest";
 import { Database } from "../database.js";

--- a/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
+++ b/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
@@ -1,0 +1,161 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+//
+// Verifies the pluggable-concurrency seam by running a client-side
+// implementation of the LES coediting model (roll-forward replay) through the
+// public `createDatabase` API, and contrasting it with the built-in
+// rebase-replay strategy on an identical scenario.
+
+import { describe, it, expect, vi } from "vitest";
+import { Database } from "../database.js";
+import { Entity } from "../../entity/entity.js";
+import { createRollForwardConcurrency } from "./roll-forward-concurrency.js";
+import { createRebaseReplayConcurrency } from "./rebase-replay-concurrency.js";
+import type { ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
+
+// A single numeric component is enough to expose the roll-forward vs
+// re-execute difference: one transaction derives its value from current state.
+const plugin = Database.Plugin.create({
+    components: {
+        counter: { type: "number" },
+    } as const,
+    resources: {},
+    archetypes: {
+        Counter: ["counter"],
+    } as const,
+    transactions: {
+        createCounter(t, args: { counter: number }) {
+            return t.archetypes.Counter.insert({ counter: args.counter });
+        },
+        // Reads current value and adds 10 — its result depends on the base
+        // state it runs against. This is the transaction whose replay semantics
+        // distinguish roll-forward from re-execute.
+        bumpFromCurrent(t, args: { entity: Entity }) {
+            const current = t.read(args.entity)?.counter ?? 0;
+            t.update(args.entity, { counter: current + 10 });
+        },
+        setAbsolute(t, args: { entity: Entity; value: number }) {
+            t.update(args.entity, { counter: args.value });
+        },
+    },
+});
+
+const makeDb = (concurrency: ConcurrencyStrategyFactory) => Database.create(plugin, { concurrency });
+
+// Seed a server-confirmed entity (positive time) so the entity exists in the
+// committed base before any optimistic local edit. Returns its id.
+const seedCommittedCounter = (db: ReturnType<typeof makeDb>, value: number): Entity => {
+    const result = db.apply({ id: 1, userId: "seed", name: "createCounter", args: { counter: value }, time: Date.now() });
+    return result!.value as Entity;
+};
+
+describe("createRollForwardConcurrency — pluggable concurrency viability", () => {
+    it("plugs into createDatabase and exposes itself as the database concurrency strategy", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        expect(db.concurrency.deferredCommit).toBe(true);
+        expect(db.concurrency.userId).toBe("A");
+    });
+
+    it("applies a server-confirmed delta directly", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 42);
+        expect(db.read(entity)?.counter).toBe(42);
+    });
+
+    it("makes a local optimistic transient visible immediately", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 0);
+
+        db.transactions.bumpFromCurrent({ entity });
+
+        // Deferred-commit: applied locally as a transient before any echo.
+        expect(db.read(entity)?.counter).toBe(10);
+    });
+
+    it("replays pending edits by rolling captured post-images forward, not by re-executing", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 0);
+
+        // Local optimistic edit: 0 -> 10, captured post-image = "set counter 10".
+        db.transactions.bumpFromCurrent({ entity });
+        expect(db.read(entity)?.counter).toBe(10);
+
+        // A peer's confirmed delta moves the base out from under the pending edit.
+        db.apply({ id: 99, userId: "B", name: "setAbsolute", args: { entity, value: 100 }, time: Date.now() + 1 });
+
+        // Roll-forward replays the *captured tuple* (set counter 10), so the
+        // pending edit's original post-image wins — NOT 110 (which is what
+        // re-executing bumpFromCurrent against the new base of 100 would give).
+        expect(db.read(entity)?.counter).toBe(10);
+    });
+
+    it("cancel discards a pending transient and restores committed state", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 5);
+
+        // Drive a cancellable transient through the dispatcher via an async
+        // generator that yields once then throws (cleanly tears down).
+        const observer = vi.fn();
+        const unobserve = db.observe.entity(entity)(observer);
+
+        db.transactions.bumpFromCurrent({ entity });
+        expect(db.read(entity)?.counter).toBe(15);
+
+        // Cancel the pending entry by its dispatcher-assigned id. The first
+        // (and only) wrapped transaction gets id 1 from the dispatcher counter.
+        db.cancel(1, "A");
+        expect(db.read(entity)?.counter).toBe(5);
+
+        unobserve();
+    });
+
+    it("reset clears the pending buffer", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 0);
+        db.transactions.bumpFromCurrent({ entity });
+        expect(db.read(entity)?.counter).toBe(10);
+
+        db.reset();
+
+        // Store is empty and the pending buffer is gone — re-seeding starts clean.
+        const reseeded = seedCommittedCounter(db, 7);
+        expect(db.read(reseeded)?.counter).toBe(7);
+    });
+
+    it("toData rolls transients back and forward around serialization without disturbing live state", () => {
+        const db = makeDb(createRollForwardConcurrency("A"));
+        const entity = seedCommittedCounter(db, 0);
+        db.transactions.bumpFromCurrent({ entity });
+        expect(db.read(entity)?.counter).toBe(10);
+
+        const snapshot = db.toData();
+        expect(snapshot).toBeTruthy();
+
+        // The onBeforeToData / onAfterToData hooks fired around serialization,
+        // so the live optimistic transient is still present afterward.
+        // (As with the built-in rebase-replay reconciler, the snapshot itself
+        // references live store buffers and is only valid until the next
+        // mutation — callers serialize it immediately.)
+        expect(db.read(entity)?.counter).toBe(10);
+    });
+});
+
+describe("roll-forward vs rebase-replay — same seam, different replay semantics", () => {
+    // Identical scenario, swapping only the concurrency strategy factory. The
+    // divergent result proves the two engines are genuinely different and that
+    // the pluggable seam selects between them with no other changes.
+    const runRebaseScenario = (concurrency: ConcurrencyStrategyFactory): number => {
+        const db = makeDb(concurrency);
+        const entity = seedCommittedCounter(db, 0);
+        db.transactions.bumpFromCurrent({ entity });
+        db.apply({ id: 99, userId: "B", name: "setAbsolute", args: { entity, value: 100 }, time: Date.now() + 1 });
+        return db.read(entity)?.counter ?? NaN;
+    };
+
+    it("roll-forward preserves the captured post-image (10)", () => {
+        expect(runRebaseScenario(createRollForwardConcurrency("A"))).toBe(10);
+    });
+
+    it("rebase-replay re-executes against the new base (110)", () => {
+        expect(runRebaseScenario(createRebaseReplayConcurrency("A"))).toBe(110);
+    });
+});

--- a/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
+++ b/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.test.ts
@@ -121,21 +121,25 @@ describe("createRollForwardConcurrency — pluggable concurrency viability", () 
         expect(db.read(reseeded)?.counter).toBe(7);
     });
 
-    it("toData rolls transients back and forward around serialization without disturbing live state", () => {
+    it("toData serializes only committed state and leaves the live transient intact", () => {
         const db = makeDb(createRollForwardConcurrency("A"));
         const entity = seedCommittedCounter(db, 0);
         db.transactions.bumpFromCurrent({ entity });
         expect(db.read(entity)?.counter).toBe(10);
 
         const snapshot = db.toData();
-        expect(snapshot).toBeTruthy();
 
-        // The onBeforeToData / onAfterToData hooks fired around serialization,
-        // so the live optimistic transient is still present afterward.
-        // (As with the built-in rebase-replay reconciler, the snapshot itself
-        // references live store buffers and is only valid until the next
-        // mutation — callers serialize it immediately.)
+        // The live optimistic transient survives the rollback→serialize→replay.
         expect(db.read(entity)?.counter).toBe(10);
+
+        // The snapshot is a detached copy of committed state only: loading it
+        // into a fresh database yields the committed base (0), not the pending
+        // optimistic value (10). This must hold even though `onAfterToData`
+        // replayed the transient back onto the live store after serialization.
+        const loaded = Database.create(plugin);
+        loaded.fromData(snapshot);
+        const loadedValues = loaded.select(["counter"]).map(e => loaded.read(e)?.counter);
+        expect(loadedValues).toEqual([0]);
     });
 });
 

--- a/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.ts
@@ -1,0 +1,156 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { applyOperations } from "../transactional-store/apply-operations.js";
+import type { TransactionResult, TransactionWriteOperation } from "../transactional-store/index.js";
+import type { TransactionEnvelope } from "../reconciling/reconciling-database.js";
+import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurrency-strategy.js";
+
+/**
+ * A pending local edit, kept in the buffer until the server confirms it.
+ * Mirrors the coediting design's `{ envelope, locallyComputedUndo }` entry
+ * shape, plus the captured post-image (`redo`) tuples.
+ */
+type RollForwardEntry = {
+    readonly id: number;
+    readonly userId?: number | string;
+    readonly time: number;
+    /**
+     * Post-image data tuples captured the first time the transaction ran.
+     * Re-applied verbatim on every rebase (roll-forward); never re-derived
+     * by re-running the transaction function. This is what makes the strategy
+     * deterministic across differing base states.
+     */
+    readonly redo: TransactionWriteOperation<unknown>[];
+    /**
+     * Locally-computed undo for the *current* base state. Recaptured on each
+     * replay because the base it must reverse changes after every rebase.
+     */
+    undo: TransactionWriteOperation<unknown>[];
+};
+
+/**
+ * Client-side implementation of the LES coediting concurrency model
+ * (Adobe-Firefly/firefly-platform#10369). Provided to prove the
+ * {@link ConcurrencyStrategy} seam can host a fundamentally different
+ * reconciliation engine than {@link createRebaseReplayConcurrency} — it is
+ * not currently wired into a real transport.
+ *
+ * The defining difference from {@link createRebaseReplayConcurrency}:
+ *
+ *   - **Roll-forward, not re-execute** (coediting decision 5B). On rebase,
+ *     each pending local edit is replayed by re-applying its captured
+ *     post-image tuples, *not* by re-running its transaction function. A
+ *     transaction that reads current state and derives a new value (e.g.
+ *     "add 10 to whatever is there") therefore preserves the value it
+ *     originally produced, regardless of how the confirmed base shifted
+ *     underneath it. Re-execution would instead recompute against the new
+ *     base.
+ *
+ * The rebase sequence on a confirmed (positive-time) delta matches the PR:
+ *   1. roll back all pending entries newest-to-oldest (apply their undo),
+ *   2. apply the confirmed delta,
+ *   3. replay the remaining pending entries oldest-to-newest by re-applying
+ *      their captured redo tuples, recapturing fresh undo against the new base.
+ *
+ * Local transients carry monotonically increasing |time| (they are appended
+ * as the user edits), so a newly-captured entry always sorts last; the buffer
+ * is kept in arrival order and a new entry is materialized on top of the
+ * replayed survivors.
+ *
+ * @param userId Stable peer/session identifier stamped on every outbound
+ *   envelope, unique across all peers sharing the same sync server.
+ */
+export const createRollForwardConcurrency = (userId: number | string): ConcurrencyStrategyFactory =>
+    (execute, getTransaction): ConcurrencyStrategy => {
+        const pending: RollForwardEntry[] = [];
+
+        const indexOfEntry = (id: number, entryUserId: number | string | undefined) =>
+            pending.findIndex(e => e.id === id && e.userId === entryUserId);
+
+        const rollbackAll = () => {
+            for (let i = pending.length - 1; i >= 0; i--) {
+                execute(t => applyOperations(t, pending[i].undo), { transient: true, userId: undefined });
+            }
+        };
+
+        // Roll-forward: re-apply each pending entry's captured post-image
+        // tuples and recapture fresh undo against the (possibly changed) base.
+        const replayAll = () => {
+            for (const entry of pending) {
+                const result = execute(
+                    t => applyOperations(t, entry.redo),
+                    { transient: true, userId: entry.userId },
+                );
+                entry.undo = result.undo;
+            }
+        };
+
+        // Run a transaction function once to materialize its effect and capture
+        // the post-image. This is the only place a transaction function runs;
+        // every subsequent rebase rolls the captured tuples forward instead.
+        const runTransaction = (envelope: TransactionEnvelope): TransactionResult<unknown> => {
+            const fn = getTransaction(envelope.name);
+            if (!fn) throw new Error(`Unknown transaction: ${envelope.name}`);
+            return execute(
+                t => fn(t, envelope.args),
+                { transient: envelope.time < 0, userId: envelope.userId },
+            );
+        };
+
+        const removeAndRebuild = (id: number, entryUserId: number | string | undefined) => {
+            const idx = indexOfEntry(id, entryUserId);
+            if (idx === -1) return;
+            rollbackAll();
+            pending.splice(idx, 1);
+            replayAll();
+        };
+
+        return {
+            deferredCommit: true,
+            userId,
+            apply(envelope) {
+                const { id, userId: envelopeUserId, time } = envelope;
+
+                // Cancel: drop the matching pending entry and rebuild.
+                if (time === 0) {
+                    removeAndRebuild(id, envelopeUserId);
+                    return undefined;
+                }
+
+                // Optimistic local transient: roll back, drop any prior version
+                // of this transaction, replay the survivors, then run the fn on
+                // top and capture its post-image tuples.
+                if (time < 0) {
+                    rollbackAll();
+                    const existing = indexOfEntry(id, envelopeUserId);
+                    if (existing !== -1) pending.splice(existing, 1);
+                    replayAll();
+                    const result = runTransaction(envelope);
+                    const isNoOp = result.redo.length === 0 && result.undo.length === 0;
+                    if (!isNoOp) {
+                        pending.push({ id, userId: envelopeUserId, time, redo: result.redo, undo: result.undo });
+                    }
+                    return result;
+                }
+
+                // Confirmed delta (positive time): roll back all pending, drop
+                // our own echo (now authoritative), apply the confirmed delta,
+                // then roll the survivors forward.
+                rollbackAll();
+                const echo = indexOfEntry(id, envelopeUserId);
+                if (echo !== -1) pending.splice(echo, 1);
+                const result = runTransaction(envelope);
+                replayAll();
+                return result;
+            },
+            cancel(id, cancelUserId) {
+                removeAndRebuild(id, cancelUserId);
+            },
+            onReset() {
+                pending.length = 0;
+            },
+            onBeforeToData: rollbackAll,
+            onAfterToData: replayAll,
+            onAfterFromData: replayAll,
+        };
+    };

--- a/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.ts
+++ b/packages/data/src/ecs/database/concurrency/roll-forward-concurrency.ts
@@ -7,8 +7,8 @@ import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "./concurre
 
 /**
  * A pending local edit, kept in the buffer until the server confirms it.
- * Mirrors the coediting design's `{ envelope, locallyComputedUndo }` entry
- * shape, plus the captured post-image (`redo`) tuples.
+ * Holds the originating envelope identity, the captured post-image (`redo`)
+ * tuples, and a locally-computed `undo`.
  */
 type RollForwardEntry = {
     readonly id: number;
@@ -29,24 +29,23 @@ type RollForwardEntry = {
 };
 
 /**
- * Client-side implementation of the LES coediting concurrency model
- * (Adobe-Firefly/firefly-platform#10369). Provided to prove the
+ * Roll-forward reconciliation: a client-side optimistic concurrency model for
+ * collaborative / multi-peer editing. Provided to prove the
  * {@link ConcurrencyStrategy} seam can host a fundamentally different
  * reconciliation engine than {@link createRebaseReplayConcurrency} — it is
  * not currently wired into a real transport.
  *
  * The defining difference from {@link createRebaseReplayConcurrency}:
  *
- *   - **Roll-forward, not re-execute** (coediting decision 5B). On rebase,
- *     each pending local edit is replayed by re-applying its captured
- *     post-image tuples, *not* by re-running its transaction function. A
- *     transaction that reads current state and derives a new value (e.g.
- *     "add 10 to whatever is there") therefore preserves the value it
- *     originally produced, regardless of how the confirmed base shifted
- *     underneath it. Re-execution would instead recompute against the new
- *     base.
+ *   - **Roll-forward, not re-execute.** On rebase, each pending local edit is
+ *     replayed by re-applying its captured post-image tuples, *not* by
+ *     re-running its transaction function. A transaction that reads current
+ *     state and derives a new value (e.g. "add 10 to whatever is there")
+ *     therefore preserves the value it originally produced, regardless of how
+ *     the confirmed base shifted underneath it. Re-execution would instead
+ *     recompute against the new base.
  *
- * The rebase sequence on a confirmed (positive-time) delta matches the PR:
+ * The rebase sequence on a confirmed (positive-time) delta:
  *   1. roll back all pending entries newest-to-oldest (apply their undo),
  *   2. apply the confirmed delta,
  *   3. replay the remaining pending entries oldest-to-newest by re-applying

--- a/packages/data/src/ecs/database/database.reset.test.ts
+++ b/packages/data/src/ecs/database/database.reset.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { Database } from "./database.js";
+import { createRebaseReplayConcurrency } from "./concurrency/index.js";
 
 // ---------------------------------------------------------------------------
 // Shared plugin
@@ -194,7 +195,7 @@ describe("Database.reset() — observer notification", () => {
 
 describe("Database.reset() — reconciler queue", () => {
     it("in-flight transients are discarded on reset", () => {
-        const db = Database.create(plugin, { sync: { userId: "u1" } });
+        const db = Database.create(plugin, { concurrency: createRebaseReplayConcurrency("u1") });
 
         // In sync mode, transactions apply as transients locally.
         db.transactions.addPoint({ x: 1, label: "transient" });

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -197,26 +197,24 @@ export interface Database<
   /**
    * Serialize the database to a plain data snapshot.
    *
-   * KNOWN BUG (pre-existing, tracked before merge): the returned snapshot
-   * holds **live references** to the store's column buffers — see
-   * `archetype.toData()` returning `{ columns: archetype.columns, ... }`. It
-   * is only valid until the next store mutation; callers must serialize it
-   * immediately.
+   * For a concurrency strategy that replays transients after serialization
+   * (`onAfterToData` — i.e. `createRebaseReplayConcurrency` /
+   * `createRollForwardConcurrency` / the legacy `createReconcilingDatabase`),
+   * this returns a snapshot **detached** from the live store: it rolls the
+   * transients back, serializes a copy of the committed state (`store.toData`
+   * with `copy: true` — columns and the entity table are cloned), then replays.
+   * So a database persisted with optimistic edits in flight contains only
+   * committed state, and the snapshot survives the subsequent replay.
    *
-   * This breaks the "exclude in-flight transients from the snapshot" intent of
-   * every concurrency strategy that uses the rollback→serialize→replay dance
-   * (`onBeforeToData`/`onAfterToData`): the synchronous `onAfterToData` replay
-   * mutates the very buffers the snapshot points at *before* the caller
-   * receives it, so a database persisted while transient/optimistic edits are
-   * pending will silently include those uncommitted edits. Affects both
-   * `createRebaseReplayConcurrency` and `createRollForwardConcurrency` (and the
-   * legacy `createReconcilingDatabase`). The existing reconciler tests never
-   * caught it because they only assert the snapshot is truthy, never round-trip
-   * it back.
+   * For strategies with no replay hook (the default `createImmediateConcurrency`),
+   * the faster live-reference snapshot is returned — it shares the store's
+   * buffers and is only valid until the next mutation, so callers must serialize
+   * it before mutating the database again.
    *
-   * Fix options under consideration: have `toData()` return a detached
-   * (deep-copied) snapshot, or restructure the hooks so serialization happens
-   * against a copy taken while transients are rolled back.
+   * Historical note: the detach above fixes a bug where the live-reference
+   * snapshot was corrupted by the post-serialization replay, silently leaking
+   * in-flight transients into persisted state. The old reconciler tests missed
+   * it because they only asserted the snapshot was truthy, never round-tripped it.
    */
   toData(): unknown
   fromData(data: unknown): void

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -194,6 +194,30 @@ export interface Database<
     /** Tier order for execution. Looser type allows extended dbs to be assignable to base. */
     readonly order: ReadonlyArray<ReadonlyArray<string>>;
   }
+  /**
+   * Serialize the database to a plain data snapshot.
+   *
+   * KNOWN BUG (pre-existing, tracked before merge): the returned snapshot
+   * holds **live references** to the store's column buffers — see
+   * `archetype.toData()` returning `{ columns: archetype.columns, ... }`. It
+   * is only valid until the next store mutation; callers must serialize it
+   * immediately.
+   *
+   * This breaks the "exclude in-flight transients from the snapshot" intent of
+   * every concurrency strategy that uses the rollback→serialize→replay dance
+   * (`onBeforeToData`/`onAfterToData`): the synchronous `onAfterToData` replay
+   * mutates the very buffers the snapshot points at *before* the caller
+   * receives it, so a database persisted while transient/optimistic edits are
+   * pending will silently include those uncommitted edits. Affects both
+   * `createRebaseReplayConcurrency` and `createRollForwardConcurrency` (and the
+   * legacy `createReconcilingDatabase`). The existing reconciler tests never
+   * caught it because they only assert the snapshot is truthy, never round-trip
+   * it back.
+   *
+   * Fix options under consideration: have `toData()` return a detached
+   * (deep-copied) snapshot, or restructure the hooks so serialization happens
+   * against a copy taken while transients are rolled back.
+   */
   toData(): unknown
   fromData(data: unknown): void
   extend<P extends Database.Plugin>(plugin: P): Database<

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -16,7 +16,8 @@ import { EntitySelectOptions } from "../store/entity-select-options.js";
 import { Filter } from "../../table/select-rows.js";
 import { Index as StoreIndex } from "../store/index-types.js";
 import type { Service } from "../../service/index.js";
-import { createDatabase, type DatabaseSyncOptions } from "./public/create-database.js";
+import { createDatabase } from "./public/create-database.js";
+import type { ConcurrencyStrategy } from "./concurrency/concurrency-strategy.js";
 import { observeSelectDeep as _observeSelectDeep } from "./public/observe-select-deep.js";
 import { ResourceSchemas } from "../resource-schemas.js";
 import { ComponentSchemas } from "../component-schemas.js";
@@ -181,13 +182,12 @@ export interface Database<
    */
   readonly cancel: (id: number, userId?: number | string) => void;
   /**
-   * The sync options the database was created with, or `undefined` for a
-   * local-only database. Sync services read this to (a) confirm the
-   * database was created in sync mode and (b) recover the `userId` for
-   * authentication / logging without having to thread it through
-   * separately.
+   * The concurrency strategy the database was created with. Sync services
+   * read `concurrency.userId` to recover the peer identifier and check
+   * `concurrency.deferredCommit` to confirm the database is in the
+   * appropriate mode for multi-peer operation.
    */
-  readonly sync: DatabaseSyncOptions | undefined;
+  readonly concurrency: ConcurrencyStrategy;
   readonly system: {
     /** System create() return value, or null when create() returns void. Key is always present. */
     readonly functions: { readonly [K in S]: SystemFunction | null };

--- a/packages/data/src/ecs/database/deep-extends-chain.type-test.ts
+++ b/packages/data/src/ecs/database/deep-extends-chain.type-test.ts
@@ -401,8 +401,8 @@ type HasStringIndex<T> = string extends keyof T ? true : false;
 // Readonly<any>=any, and any & EntityReadValues<C> = any, which is
 // assignable to any concrete return type.
 //
-// This test reproduces the pattern used by consumers like firefly-platform's
-// MainService interface to verify that the assignment compiles.
+// This test reproduces the pattern used by downstream consumers' service
+// interfaces to verify that the assignment compiles.
 // ============================================================================
 
 import type { ReadonlyArchetype } from "../archetype/archetype.js";

--- a/packages/data/src/ecs/database/index.ts
+++ b/packages/data/src/ecs/database/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./public/create-database.js";
 export * from "./public/observe-select-deep.js";
+export * from "./concurrency/index.js";
 export * from "./reconciling/create-reconciling-database.js";
 export * from "./reconciling/reconciling-database.js";
 export * from "./reconciling/reconciling-entry.js";

--- a/packages/data/src/ecs/database/observed/create-observed-database.ts
+++ b/packages/data/src/ecs/database/observed/create-observed-database.ts
@@ -180,7 +180,7 @@ export function createObservedDatabase<
             store.reset();
             notifyAllObserversStoreReloaded();
         },
-        toData: () => store.toData(),
+        toData: (copy = false) => store.toData(copy),
         fromData: (data: unknown) => {
             store.fromData(data);
             notifyAllObserversStoreReloaded();

--- a/packages/data/src/ecs/database/observed/observed-database.ts
+++ b/packages/data/src/ecs/database/observed/observed-database.ts
@@ -36,7 +36,7 @@ export interface ObservedDatabase<
     };
     readonly execute: (handler: (ctx: TransactionContext<C, R, A>) => Entity | void, options?: { transient?: boolean; userId?: number | string }) => TransactionResult<C>;
     readonly reset: () => void;
-    readonly toData: () => unknown;
+    readonly toData: (copy?: boolean) => unknown;
     readonly fromData: (data: unknown) => void;
     readonly extend: <
         P extends Database.Plugin<any, any, any, any, any>

--- a/packages/data/src/ecs/database/public/create-database.test.ts
+++ b/packages/data/src/ecs/database/public/create-database.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { Database } from "../database.js";
 import { createReconcilingDatabase } from "../reconciling/create-reconciling-database.js";
+import { createRebaseReplayConcurrency } from "../concurrency/index.js";
 import { Store } from "../../store/index.js";
 import { Schema } from "../../../schema/index.js";
 import { Entity } from "../../entity/entity.js";
@@ -1697,14 +1698,14 @@ describe("userId in transaction context", () => {
     });
 
     it("t.userId matches sync.userId for locally-initiated transactions", () => {
-        const db = Database.create(makePlugin(), { sync: { userId: "alice" } });
+        const db = Database.create(makePlugin(), { concurrency: createRebaseReplayConcurrency("alice") });
         db.transactions.capture();
         expect(db.resources.seen).toBe("alice");
     });
 
     it("t.userId matches the envelope userId for inbound db.apply(envelope) calls", () => {
         const plugin = makePlugin();
-        const db = Database.create(plugin, { sync: { userId: "alice" } });
+        const db = Database.create(plugin, { concurrency: createRebaseReplayConcurrency("alice") });
 
         // Build a committed envelope that looks like it came from "bob"
         const envelope = { id: 1, userId: "bob", name: "capture", args: undefined, time: 1 };
@@ -1734,7 +1735,7 @@ describe("no-op envelope suppression", () => {
     });
 
     it("a no-op commit (wrong userId) does not fire observe.envelopes", () => {
-        const db = Database.create(makeGatedPlugin(), { sync: { userId: "O" } });
+        const db = Database.create(makeGatedPlugin(), { concurrency: createRebaseReplayConcurrency("O") });
 
         const listener = vi.fn();
         db.observe.envelopes(listener);
@@ -1746,7 +1747,7 @@ describe("no-op envelope suppression", () => {
     });
 
     it("an effective commit (correct userId) does fire observe.envelopes", () => {
-        const db = Database.create(makeGatedPlugin(), { sync: { userId: "X" } });
+        const db = Database.create(makeGatedPlugin(), { concurrency: createRebaseReplayConcurrency("X") });
 
         const listener = vi.fn();
         db.observe.envelopes(listener);

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -130,9 +130,17 @@ function createEmptyDatabase(concurrency: ConcurrencyStrategyFactory | undefined
     // truth.
 
     const toData = () => {
+        // Fast path: a strategy with no replay hook leaves the store untouched
+        // after serialization, so a live-reference snapshot is safe.
+        if (!strategy.onAfterToData) {
+            return observedDatabase.toData();
+        }
+        // A replay strategy mutates the live buffers in `onAfterToData`, which
+        // would corrupt a live-reference snapshot. Capture a detached copy of
+        // the committed (rolled-back) state before replaying.
         strategy.onBeforeToData?.();
-        const data = observedDatabase.toData();
-        strategy.onAfterToData?.();
+        const data = observedDatabase.toData(true);
+        strategy.onAfterToData();
         return data;
     };
     const fromData = (data: unknown) => {

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -2,10 +2,12 @@
 
 import { ReadonlyStore, Store } from "../../store/index.js";
 import { Database, FromServiceFactories } from "../database.js";
-import { createReconcilingDatabase } from "../reconciling/create-reconciling-database.js";
 import { calculateSystemOrder } from "../calculate-system-order.js";
 import { createTransactionDispatcher } from "./create-transaction-dispatcher.js";
 import { observeSelectEntities } from "../observe-select-entities.js";
+import { createObservedDatabase } from "../observed/create-observed-database.js";
+import { createImmediateConcurrency } from "../concurrency/immediate-concurrency.js";
+import type { ConcurrencyStrategy, ConcurrencyStrategyFactory } from "../concurrency/concurrency-strategy.js";
 import type { Entity } from "../../entity/entity.js";
 
 /**
@@ -25,31 +27,6 @@ function createAndAssignSystems(
     }
 }
 
-/**
- * Sync-related options. Presence of `sync` means "this database is going to
- * be attached to a sync service", which has two consequences:
- *
- *   1. Every locally-generated `TransactionEnvelope` is stamped with
- *      `userId`, and the reconciler keys its transient queue by the
- *      compound `(userId, id)` so two peers' independent local id counters
- *      cannot collide.
- *   2. The transaction wrapper enters deferred-commit mode: calls to
- *      `db.transactions.X(args)` apply locally as transients (negative
- *      time) and wait for the server's echoed `committed` envelope to
- *      promote them via the reconciler's rebase-replay. This is required
- *      for cross-peer entity-id determinism under concurrent edits.
- *
- * If `sync` is omitted the database operates in local-only mode: commits
- * apply immediately with positive time, no envelope stamping, no deferred
- * promotion.
- */
-export interface DatabaseSyncOptions {
-    /**
-     * Stable peer/session identifier. Must be unique across all peers
-     * sharing the same sync server.
-     */
-    readonly userId: number | string;
-}
 
 interface CreateDatabaseOptions<P extends Database.Plugin<any, any, any, any, any, any, any, any>> {
     /**
@@ -57,8 +34,17 @@ interface CreateDatabaseOptions<P extends Database.Plugin<any, any, any, any, an
      * For each service injected here, we will use it and not call the normal service factory function.
      */
     services?: { [K in keyof FromServiceFactories<P['services']>]?: FromServiceFactories<P['services']>[K] };
-    /** See {@link DatabaseSyncOptions}. */
-    sync?: DatabaseSyncOptions;
+    /**
+     * Concurrency strategy that controls how locally-initiated transactions
+     * are applied and how inbound envelopes are reconciled.
+     *
+     * Built-in strategies:
+     *   - `createImmediateConcurrency()` — commits apply immediately, no
+     *     rollback queue. Default when omitted.
+     *   - `createRebaseReplayConcurrency(userId)` — deferred-commit mode with
+     *     full rollback-and-replay for multi-peer synchronisation.
+     */
+    concurrency?: ConcurrencyStrategyFactory;
 }
 
 export function createDatabase(): Database<{}, {}, {}, {}, never, {}, {}, {}>
@@ -72,7 +58,7 @@ export function createDatabase(
     plugin?: Database.Plugin<any, any, any, any, any, any, any, any>,
     options?: CreateDatabaseOptions<any>,
 ): any {
-    const db = createEmptyDatabase(options?.sync);
+    const db = createEmptyDatabase(options?.concurrency);
     if (plugin === undefined) {
         return db;
     }
@@ -86,21 +72,33 @@ export function createDatabase(
  * Creates a database with empty store, no transactions, actions, services, computed, or systems.
  * All content is added via .extend(plugin). Single code path for extension.
  */
-function createEmptyDatabase(sync: DatabaseSyncOptions | undefined): any {
+function createEmptyDatabase(concurrency: ConcurrencyStrategyFactory | undefined): any {
     const store = Store.create({
         components: {},
         resources: {},
         archetypes: {},
     });
-    const reconcilingDatabase = createReconcilingDatabase(store, {} as any);
+
+    const observedDatabase = createObservedDatabase(store);
+
+    // The transaction declarations dict is shared with the strategy via the
+    // getTransaction closure: extend() updates it, the strategy reads from it.
+    const transactionDeclarationsRef: Record<string, ((ctx: any, args: unknown) => void | Entity) | undefined> = {};
+    const getTransaction = (name: string) => transactionDeclarationsRef[name];
+
+    const strategyFactory = concurrency ?? createImmediateConcurrency();
+    const strategy: ConcurrencyStrategy = strategyFactory(observedDatabase.execute, getTransaction);
 
     // The dispatcher owns everything envelope-related: id allocation,
     // commit/transient/cancel intent decisions, the deferred-commit
-    // behaviour implied by sync mode, and resolving plain/promise/async-
+    // behaviour implied by the strategy, and resolving plain/promise/async-
     // generator argument shapes. We just plug its outputs into the
     // database surface.
-    const dispatcher = createTransactionDispatcher(reconcilingDatabase.apply, sync);
-    (reconcilingDatabase.observe as any).envelopes = dispatcher.envelopes;
+    const dispatcher = createTransactionDispatcher(strategy.apply, {
+        deferredCommit: strategy.deferredCommit,
+        userId: strategy.userId,
+    });
+    (observedDatabase.observe as any).envelopes = dispatcher.envelopes;
 
     const transactions: any = { serviceName: "ecs-database-transactions-service" };
     const addTransactionWrappers = (transactionDecls: Record<string, any>) => {
@@ -131,10 +129,25 @@ function createEmptyDatabase(sync: DatabaseSyncOptions | undefined): any {
     // `db.indexes.<name>` and `t.indexes.<name>` pointing at one source of
     // truth.
 
+    const toData = strategy.toData
+        ? () => strategy.toData!(() => observedDatabase.toData())
+        : () => observedDatabase.toData();
+    const fromData = strategy.fromData
+        ? (data: unknown) => strategy.fromData!((d) => observedDatabase.fromData(d), data)
+        : (data: unknown) => observedDatabase.fromData(data);
+
     const partialDatabase: any = {
         serviceName: "ecs-database-service",
-        ...reconcilingDatabase,
-        sync,
+        ...observedDatabase,
+        concurrency: strategy,
+        apply: strategy.apply,
+        cancel: strategy.cancel,
+        reset: () => {
+            strategy.onReset();
+            observedDatabase.reset();
+        },
+        toData,
+        fromData,
         transactions,
         actions,
         services,
@@ -180,7 +193,14 @@ function createEmptyDatabase(sync: DatabaseSyncOptions | undefined): any {
     const extend = (plugin: Database.Plugin<any, any, any, any, any, any, any, any>) => {
         if (!extendedPlugins.has(plugin)) {
             extendedPlugins.add(plugin);
-            reconcilingDatabase.extend(plugin);
+            observedDatabase.extend(plugin);
+
+            // Update the shared transaction declarations ref so the strategy's
+            // getTransaction closure sees the new names during replay.
+            if (plugin.transactions) {
+                Object.assign(transactionDeclarationsRef, plugin.transactions);
+            }
+
             const pluginTransactions = plugin.transactions ?? {};
             const pluginActions = plugin.actions ?? {};
             const pluginServices = plugin.services ?? {};
@@ -193,7 +213,7 @@ function createEmptyDatabase(sync: DatabaseSyncOptions | undefined): any {
             for (const name in pluginComputed) {
                 if (!(name in computed)) computed[name] = (pluginComputed[name] as (db: any) => unknown)(partialDatabase);
             }
-            // `reconcilingDatabase.extend(plugin)` above propagates down to
+            // `observedDatabase.extend(plugin)` above propagates down to
             // `store.extend({ components, resources, archetypes, indexes })`,
             // so the Store has already absorbed `plugin.indexes`. We refresh
             // our local indexes reference in case the underlying map got a

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -129,12 +129,16 @@ function createEmptyDatabase(concurrency: ConcurrencyStrategyFactory | undefined
     // `db.indexes.<name>` and `t.indexes.<name>` pointing at one source of
     // truth.
 
-    const toData = strategy.toData
-        ? () => strategy.toData!(() => observedDatabase.toData())
-        : () => observedDatabase.toData();
-    const fromData = strategy.fromData
-        ? (data: unknown) => strategy.fromData!((d) => observedDatabase.fromData(d), data)
-        : (data: unknown) => observedDatabase.fromData(data);
+    const toData = () => {
+        strategy.onBeforeToData?.();
+        const data = observedDatabase.toData();
+        strategy.onAfterToData?.();
+        return data;
+    };
+    const fromData = (data: unknown) => {
+        observedDatabase.fromData(data);
+        strategy.onAfterFromData?.();
+    };
 
     const partialDatabase: any = {
         serviceName: "ecs-database-service",

--- a/packages/data/src/ecs/database/public/create-transaction-dispatcher.ts
+++ b/packages/data/src/ecs/database/public/create-transaction-dispatcher.ts
@@ -5,7 +5,6 @@ import { isAsyncGenerator } from "../../../internal/async-generator/is-async-gen
 import { Observe } from "../../../observe/index.js";
 import { TransactionEnvelope } from "../reconciling/reconciling-database.js";
 import { TransactionResult } from "../transactional-store/index.js";
-import type { DatabaseSyncOptions } from "./create-database.js";
 
 /**
  * Why an envelope intent matters: from the wire's perspective both a deferred
@@ -70,17 +69,11 @@ export interface TransactionDispatcher {
 
 export const createTransactionDispatcher = (
     apply: DispatcherTarget,
-    sync: DatabaseSyncOptions | undefined,
+    options: { deferredCommit: boolean; userId?: number | string },
 ): TransactionDispatcher => {
     const [envelopes, notifyEnvelope] = Observe.createEvent<TransactionEnvelopeEvent>();
 
-    // Sync mode is decided once at construction. Presence of `sync` means:
-    //   - userId is stamped on every envelope
-    //   - "commit" intents apply locally as transients (negative time) and
-    //     wait for the sync server's echoed `committed` envelope to promote
-    //     them via the reconciler's rebase-replay
-    const userId = sync?.userId;
-    const deferredCommit = sync !== undefined;
+    const { deferredCommit, userId } = options;
 
     let nextTransactionId = 1;
 

--- a/packages/data/src/ecs/database/reconciling/create-rebase-replay-applier.ts
+++ b/packages/data/src/ecs/database/reconciling/create-rebase-replay-applier.ts
@@ -1,0 +1,151 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { applyOperations } from "../transactional-store/apply-operations.js";
+import { TransactionResult } from "../transactional-store/index.js";
+import { TransactionEnvelope } from "./reconciling-database.js";
+import { ReconcilingEntry, ReconcilingEntryOps } from "./reconciling-entry.js";
+import type { ConcurrencyExecuteFn, ConcurrencyGetTransactionFn } from "../concurrency/concurrency-strategy.js";
+
+/**
+ * Core rebase-replay logic shared by {@link createReconcilingDatabase} (legacy
+ * typed API) and {@link createRebaseReplayConcurrency} (pluggable strategy).
+ *
+ * Given an `execute` function (from the observed database layer) and a
+ * `getTransaction` lookup, manages a pending-transient queue and provides
+ * the rollback-and-replay protocol:
+ *
+ *   1. Roll back all transients in reverse stack order.
+ *   2. Apply the committed envelope once (non-transient).
+ *   3. Replay the surviving transients on top.
+ *
+ * This guarantees the freelist / nextIndex snapshot at step 2 is identical
+ * on every peer, regardless of what local transients were pending when the
+ * broadcast arrived.
+ */
+export function createRebaseReplayApplier(
+    execute: ConcurrencyExecuteFn,
+    getTransaction: ConcurrencyGetTransactionFn,
+): {
+    apply: (envelope: TransactionEnvelope) => TransactionResult<unknown> | undefined;
+    cancel: (id: number, userId?: number | string) => void;
+    onReset: () => void;
+    toData: (base: () => unknown) => unknown;
+    fromData: (base: (data: unknown) => void, data: unknown) => void;
+} {
+    const reconcilingEntries: ReconcilingEntry[] = [];
+
+    const rollbackEntryResult = (entry: ReconcilingEntry) => {
+        if (entry.result) {
+            execute(t => applyOperations(t, entry.result!.undo), { transient: true, userId: undefined });
+            entry.result = undefined;
+        }
+    };
+
+    const rollbackAllTransients = () => {
+        for (let i = reconcilingEntries.length - 1; i >= 0; i--) {
+            rollbackEntryResult(reconcilingEntries[i]);
+        }
+    };
+
+    const executeEntry = (entry: ReconcilingEntry) => {
+        const fn = getTransaction(entry.name);
+        if (!fn) throw new Error(`Unknown transaction during replay: ${entry.name}`);
+        const result = execute(t => fn(t, entry.args), { transient: true, userId: entry.userId });
+        const isNoOp = result.redo.length === 0 && result.undo.length === 0;
+        entry.result = isNoOp ? undefined : result;
+        return result;
+    };
+
+    const replayAllTransients = () => {
+        let lastResult: TransactionResult<unknown> | undefined;
+        for (const entry of reconcilingEntries) {
+            lastResult = executeEntry(entry);
+        }
+        return lastResult;
+    };
+
+    const spliceTransientEntry = (id: number, userId: number | string | undefined): boolean => {
+        const index = reconcilingEntries.findIndex(e => e.id === id && e.userId === userId);
+        if (index === -1) return false;
+        reconcilingEntries.splice(index, 1);
+        return true;
+    };
+
+    const apply = (envelope: TransactionEnvelope): TransactionResult<unknown> | undefined => {
+        const { id, userId, time, args } = envelope;
+
+        if (time === 0) {
+            const index = reconcilingEntries.findIndex(e => e.id === id && e.userId === userId);
+            if (index === -1) return undefined;
+            rollbackAllTransients();
+            reconcilingEntries.splice(index, 1);
+            replayAllTransients();
+            return undefined;
+        }
+
+        if (time < 0) {
+            const fn = getTransaction(envelope.name);
+            if (!fn) throw new Error(`Unknown transaction: ${envelope.name}`);
+
+            rollbackAllTransients();
+            spliceTransientEntry(id, userId);
+
+            const entry: ReconcilingEntry = {
+                id,
+                userId,
+                name: envelope.name,
+                transaction: fn,
+                args,
+                time,
+                result: undefined,
+            };
+
+            const insertIndex = ReconcilingEntryOps.findInsertIndex(reconcilingEntries, entry);
+            reconcilingEntries.splice(insertIndex, 0, entry);
+
+            const result = replayAllTransients();
+
+            if (entry.result === undefined) {
+                const idx = reconcilingEntries.indexOf(entry);
+                if (idx !== -1) reconcilingEntries.splice(idx, 1);
+            }
+
+            return result;
+        }
+
+        // Positive time: committed. Rebase transient queue around this commit.
+        const fn = getTransaction(envelope.name);
+        if (!fn) throw new Error(`Unknown transaction: ${envelope.name}`);
+        rollbackAllTransients();
+        spliceTransientEntry(id, userId);
+        const result = execute(t => fn(t, args), { transient: false, userId });
+        replayAllTransients();
+        return result;
+    };
+
+    const cancel = (id: number, userId?: number | string) => {
+        const index = reconcilingEntries.findIndex(e => e.id === id && e.userId === userId);
+        if (index === -1) return;
+        rollbackAllTransients();
+        reconcilingEntries.splice(index, 1);
+        replayAllTransients();
+    };
+
+    const onReset = () => {
+        reconcilingEntries.length = 0;
+    };
+
+    const toData = (base: () => unknown): unknown => {
+        rollbackAllTransients();
+        const data = base();
+        replayAllTransients();
+        return data;
+    };
+
+    const fromData = (base: (data: unknown) => void, data: unknown): void => {
+        base(data);
+        replayAllTransients();
+    };
+
+    return { apply, cancel, onReset, toData, fromData };
+}

--- a/packages/data/src/ecs/database/reconciling/create-rebase-replay-applier.ts
+++ b/packages/data/src/ecs/database/reconciling/create-rebase-replay-applier.ts
@@ -4,7 +4,7 @@ import { applyOperations } from "../transactional-store/apply-operations.js";
 import { TransactionResult } from "../transactional-store/index.js";
 import { TransactionEnvelope } from "./reconciling-database.js";
 import { ReconcilingEntry, ReconcilingEntryOps } from "./reconciling-entry.js";
-import type { ConcurrencyExecuteFn, ConcurrencyGetTransactionFn } from "../concurrency/concurrency-strategy.js";
+import type { ConcurrencyStrategyFactory } from "../concurrency/concurrency-strategy.js";
 
 /**
  * Core rebase-replay logic shared by {@link createReconcilingDatabase} (legacy
@@ -23,15 +23,15 @@ import type { ConcurrencyExecuteFn, ConcurrencyGetTransactionFn } from "../concu
  * broadcast arrived.
  */
 export function createRebaseReplayApplier(
-    execute: ConcurrencyExecuteFn,
-    getTransaction: ConcurrencyGetTransactionFn,
+    ...args: Parameters<ConcurrencyStrategyFactory>
 ): {
     apply: (envelope: TransactionEnvelope) => TransactionResult<unknown> | undefined;
     cancel: (id: number, userId?: number | string) => void;
     onReset: () => void;
-    toData: (base: () => unknown) => unknown;
-    fromData: (base: (data: unknown) => void, data: unknown) => void;
+    rollbackAllTransients: () => void;
+    replayAllTransients: () => TransactionResult<unknown> | undefined;
 } {
+    const [execute, getTransaction] = args;
     const reconcilingEntries: ReconcilingEntry[] = [];
 
     const rollbackEntryResult = (entry: ReconcilingEntry) => {
@@ -135,17 +135,5 @@ export function createRebaseReplayApplier(
         reconcilingEntries.length = 0;
     };
 
-    const toData = (base: () => unknown): unknown => {
-        rollbackAllTransients();
-        const data = base();
-        replayAllTransients();
-        return data;
-    };
-
-    const fromData = (base: (data: unknown) => void, data: unknown): void => {
-        base(data);
-        replayAllTransients();
-    };
-
-    return { apply, cancel, onReset, toData, fromData };
+    return { apply, cancel, onReset, rollbackAllTransients, replayAllTransients };
 }

--- a/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
+++ b/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
@@ -51,8 +51,16 @@ export function createReconcilingDatabase<
             applier.onReset();
             observedDatabase.reset();
         },
-        toData: () => applier.toData(() => observedDatabase.toData()),
-        fromData: (data: unknown) => applier.fromData((d) => observedDatabase.fromData(d), data),
+        toData: () => {
+            applier.rollbackAllTransients();
+            const data = observedDatabase.toData();
+            applier.replayAllTransients();
+            return data;
+        },
+        fromData: (data: unknown) => {
+            observedDatabase.fromData(data);
+            applier.replayAllTransients();
+        },
         apply: applier.apply as ReconcilingDatabase<C, R, A, TD>["apply"],
         cancel: applier.cancel,
         extend: (plugin: any) => {

--- a/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
+++ b/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
@@ -32,8 +32,6 @@ export function createReconcilingDatabase<
     store: Store<C, R, A>,
     transactionDeclarations: TD,
 ): ReconcilingDatabase<C, R, A, TD> {
-    type TransactionName = Extract<keyof TD, string>;
-
     const transactionDeclarationsRef: TransactionDeclarations<C, R, A> = {
         ...transactionDeclarations,
     };

--- a/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
+++ b/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
@@ -50,8 +50,10 @@ export function createReconcilingDatabase<
             observedDatabase.reset();
         },
         toData: () => {
+            // Detach the snapshot from live buffers: replayAllTransients below
+            // mutates them and would otherwise corrupt the returned snapshot.
             applier.rollbackAllTransients();
-            const data = observedDatabase.toData();
+            const data = observedDatabase.toData(true);
             applier.replayAllTransients();
             return data;
         },

--- a/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
+++ b/packages/data/src/ecs/database/reconciling/create-reconciling-database.ts
@@ -1,18 +1,28 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
 import { StringKeyof } from "../../../types/types.js";
-import { TransactionContext, TransactionResult } from "../transactional-store/index.js";
-import { applyOperations } from "../transactional-store/apply-operations.js";
 import type { TransactionDeclarations } from "../../store/transaction-functions.js";
 import { ResourceComponents } from "../../store/resource-components.js";
 import { Store } from "../../store/index.js";
 import { Components } from "../../store/components.js";
 import { ArchetypeComponents } from "../../store/archetype-components.js";
-import { ReconcilingDatabase, TransactionEnvelope } from "./reconciling-database.js";
-import { ReconcilingEntry, ReconcilingEntryOps } from "./reconciling-entry.js";
+import { ReconcilingDatabase } from "./reconciling-database.js";
 import { createObservedDatabase } from "../observed/create-observed-database.js";
+import { createRebaseReplayApplier } from "./create-rebase-replay-applier.js";
 import { Entity } from "../../entity/entity.js";
+import { Database } from "../database.js";
 
+/**
+ * Creates a database that wraps `store` with the rebase-replay reconciliation
+ * protocol on top of an observed database.
+ *
+ * Prefer {@link createRebaseReplayConcurrency} when building a new database
+ * via {@link createDatabase} — it plugs into the concurrency-strategy seam
+ * and composes cleanly with the rest of the database construction path.
+ *
+ * This function is kept for direct use (e.g. tests, lower-level tooling)
+ * where the full `Database` surface is not needed.
+ */
 export function createReconcilingDatabase<
     const C extends Components,
     const R extends ResourceComponents,
@@ -29,182 +39,24 @@ export function createReconcilingDatabase<
     };
 
     const observedDatabase = createObservedDatabase(store);
-    const {
-        execute,
-        observe,
-        resources,
-        toData: observedToData,
-        fromData: observedFromData,
-        ...storeMethods
-    } = observedDatabase;
 
-    const reconcilingEntries: ReconcilingEntry<C, R, A>[] = [];
+    const getTransaction = (name: string) =>
+        (transactionDeclarationsRef as Record<string, ((ctx: any, args: unknown) => void | Entity) | undefined>)[name];
 
-    const rollbackEntryResult = (entry: ReconcilingEntry<C, R, A>) => {
-        if (entry.result) {
-            execute(t => applyOperations(t, entry.result!.undo), { transient: true, userId: undefined });
-            entry.result = undefined;
-        }
-    };
-
-    const rollbackAllTransients = () => {
-        for (let i = reconcilingEntries.length - 1; i >= 0; i--) {
-            rollbackEntryResult(reconcilingEntries[i]);
-        }
-    };
-
-    /**
-     * Splice a transient entry out of the queue by compound (userId, id) key.
-     * IMPORTANT: must only be called when all transients are already rolled back
-     * (i.e. after rollbackAllTransients()). Calling it while entries are still
-     * applied would undo a non-top entry mid-stack, corrupting the freelist.
-     */
-    const spliceTransientEntry = (id: number, userId: number | string | undefined): boolean => {
-        const index = reconcilingEntries.findIndex(entry => entry.id === id && entry.userId === userId);
-        if (index === -1) {
-            return false;
-        }
-        reconcilingEntries.splice(index, 1);
-        return true;
-    };
-
-    const executeEntry = (entry: ReconcilingEntry<C, R, A>) => {
-        const result = execute(
-            t => entry.transaction(t, entry.args),
-            { transient: true, userId: entry.userId },
-        );
-
-        // Only store result if it actually made changes (not a no-op).
-        // A no-op transaction has empty redo/undo operations.
-        const isNoOp = result.redo.length === 0 && result.undo.length === 0;
-        entry.result = isNoOp ? undefined : result;
-
-        return result;
-    };
-
-    const replayAllTransients = () => {
-        let lastResult: TransactionResult<C> | undefined;
-        for (const entry of reconcilingEntries) {
-            lastResult = executeEntry(entry);
-        }
-        return lastResult;
-    };
-
-    const applyEnvelope = (envelope: TransactionEnvelope<TransactionName>): TransactionResult<C> | undefined => {
-        const transaction = transactionDeclarationsRef[envelope.name];
-        if (!transaction) {
-            throw new Error(`Unknown transaction: ${envelope.name as string}`);
-        }
-
-        const { id, userId, time, args } = envelope;
-        const transactionFn = transaction as (ctx: TransactionContext<C, R, A>, args: unknown) => void | Entity;
-
-        // Handle cancellation: remove any transient entry for this (userId, id).
-        if (time === 0) {
-            const index = reconcilingEntries.findIndex(entry => entry.id === id && entry.userId === userId);
-            if (index === -1) {
-                return undefined;
-            }
-            rollbackAllTransients();
-            reconcilingEntries.splice(index, 1);
-            replayAllTransients();
-            return undefined;
-        }
-
-        // Handle transient application (negative time).
-        if (time < 0) {
-            // Roll everything back before touching the queue so each undo is
-            // applied in reverse stack order (avoids mid-stack partial undos
-            // that would corrupt the freelist).
-            rollbackAllTransients();
-            spliceTransientEntry(id, userId);
-
-            // Create and insert the new transient entry.
-            const entry: ReconcilingEntry<C, R, A> = {
-                id,
-                userId,
-                name: envelope.name,
-                transaction: transactionFn,
-                args,
-                time,
-                result: undefined,
-            };
-
-            const insertIndex = ReconcilingEntryOps.findInsertIndex(reconcilingEntries, entry);
-            reconcilingEntries.splice(insertIndex, 0, entry);
-
-            // Rebuild transient state from scratch to respect time ordering.
-            const result = replayAllTransients();
-
-            // If the new entry produced no store changes (no-op), remove it
-            // from the queue immediately. It will never receive a server
-            // promotion and would otherwise sit in the queue uselessly.
-            if (entry.result === undefined) {
-                const idx = reconcilingEntries.indexOf(entry);
-                if (idx !== -1) reconcilingEntries.splice(idx, 1);
-            }
-
-            return result;
-        }
-
-        // Handle committed application (positive time): rebase the entire
-        // transient queue around it so deterministic id allocation matches
-        // every other peer's view.
-        //   1. Roll back all transients in reverse stack order (avoids
-        //      mid-stack partial undos that corrupt the freelist).
-        //   2. Splice out the matching transient (already rolled back).
-        //   3. Apply the committed envelope once (non-transient).
-        //   4. Replay the surviving transients on top.
-        // This guarantees the freelist / nextIndex snapshot at step 3 is
-        // identical on every peer, regardless of what local transients were
-        // pending when the broadcast arrived.
-        rollbackAllTransients();
-        spliceTransientEntry(id, userId);
-        const result = execute(
-            t => transactionFn(t, args),
-            { transient: false, userId },
-        );
-        replayAllTransients();
-        return result;
-    };
-
-    const cancelEntry = (id: number, userId?: number | string) => {
-        const index = reconcilingEntries.findIndex(entry => entry.id === id && entry.userId === userId);
-        if (index === -1) {
-            return;
-        }
-        rollbackAllTransients();
-        reconcilingEntries.splice(index, 1);
-        replayAllTransients();
-    };
-
-    const resetReconciling = () => {
-        reconcilingEntries.length = 0;
-        observedDatabase.reset();
-    };
+    const applier = createRebaseReplayApplier(observedDatabase.execute, getTransaction);
 
     const reconcilingDatabase: ReconcilingDatabase<C, R, A, TD> = {
-        ...storeMethods,
-        resources,
-        execute,
-        observe,
-        reset: resetReconciling,
-        toData: () => {
-            rollbackAllTransients();
-            const data = observedToData();
-            replayAllTransients();
-            return data;
+        ...observedDatabase,
+        reset: () => {
+            applier.onReset();
+            observedDatabase.reset();
         },
-        fromData: (data: unknown) => {
-            observedFromData(data);
-            replayAllTransients();
-        },
-        apply: applyEnvelope,
-        cancel: cancelEntry,
+        toData: () => applier.toData(() => observedDatabase.toData()),
+        fromData: (data: unknown) => applier.fromData((d) => observedDatabase.fromData(d), data),
+        apply: applier.apply as ReconcilingDatabase<C, R, A, TD>["apply"],
+        cancel: applier.cancel,
         extend: (plugin: any) => {
-            // Extend the underlying observed database (which extends transactionalStore -> store)
             observedDatabase.extend(plugin);
-            // Extend our transaction declarations
             if (plugin.transactions) {
                 Object.assign(transactionDeclarationsRef, plugin.transactions);
             }
@@ -214,4 +66,3 @@ export function createReconcilingDatabase<
 
     return reconcilingDatabase;
 }
-

--- a/packages/data/src/ecs/entity-location-table/create-entity-location-table.ts
+++ b/packages/data/src/ecs/entity-location-table/create-entity-location-table.ts
@@ -96,8 +96,8 @@ const createPositiveEntityLocationTable = (initialCapacity: number = 16): Entity
             freeListHead = -1;
             nextIndex = 0;
         },
-        toData: () => ({
-            entities,
+        toData: (copy = false) => ({
+            entities: copy ? entities.slice() : entities,
             freeListHead,
             nextIndex,
             capacity,

--- a/packages/data/src/ecs/entity-location-table/entity-location-table.ts
+++ b/packages/data/src/ecs/entity-location-table/entity-location-table.ts
@@ -9,6 +9,12 @@ export interface EntityLocationTable {
     locate: (entity: Entity) => EntityLocation | null;
     /** Wipe all entity records. O(1). Next allocate starts from entity 0 again. */
     reset: () => void;
-    toData: () => unknown;
+    /**
+     * Serialize the table. When `copy` is true the backing `entities` buffer is
+     * detached (sliced) so the snapshot survives later mutation of the live
+     * table; otherwise the snapshot references the live buffer (faster, but only
+     * valid until the next mutation).
+     */
+    toData: (copy?: boolean) => unknown;
     fromData: (data: unknown) => void;
 }

--- a/packages/data/src/ecs/store/core/core.ts
+++ b/packages/data/src/ecs/store/core/core.ts
@@ -33,7 +33,13 @@ export interface ReadonlyCore<
     read<T extends RequiredComponents>(entity: Entity, minArchetype: ReadonlyArchetype<T> | Archetype<T>): Readonly<T> & EntityReadValues<C> | null;
     read(entity: Entity): EntityReadValues<C> | null;
     get<K extends StringKeyof<C>>(entity: Entity, component: K): C[K] | undefined;
-    toData(): unknown
+    /**
+     * Serialize the core. When `copy` is true the snapshot is detached from the
+     * live store (column and entity buffers are copied) so it survives later
+     * mutation; otherwise it references live buffers — faster, but only valid
+     * until the next mutation. See {@link Store.toData} bug notes.
+     */
+    toData(copy?: boolean): unknown
 }
 
 /**

--- a/packages/data/src/ecs/store/core/create-core.ts
+++ b/packages/data/src/ecs/store/core/create-core.ts
@@ -200,10 +200,10 @@ export function createCore<NC extends ComponentSchemas>(newComponentSchemas: NC)
         update: updateEntity,
         compact,
         reset: resetCore,
-        toData: () => ({
+        toData: (copy = false) => ({
             componentSchemas,
-            entityLocationTableData: persistentLocationTable.toData(),
-            archetypesData: archetypes.map(archetype => archetype.toData())
+            entityLocationTableData: persistentLocationTable.toData(copy),
+            archetypesData: archetypes.map(archetype => archetype.toData(copy))
         }),
         fromData: (data: any) => {
             Object.assign(componentSchemas, data.componentSchemas);

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -619,6 +619,34 @@ describe("createStore", () => {
             expect(newStore.resources.config).toEqual({ debug: true, volume: 0.5 });
         });
 
+        it("toData(true) detaches the snapshot from later store mutation; toData() references live buffers", () => {
+            const makePopulatedStore = () => {
+                const store = createStore({ components: { health: healthSchema }, resources: {}, archetypes: {} });
+                const archetype = store.ensureArchetype(["id", "health"]);
+                const entity = archetype.insert({ health: { current: 100, max: 100 } });
+                return { store, entity };
+            };
+            const restore = (snapshot: unknown) => {
+                const fresh = createStore({ components: { health: healthSchema }, resources: {}, archetypes: {} });
+                fresh.fromData(snapshot);
+                const restored = fresh.select(["health"]);
+                return fresh.read(restored[0])?.health.current;
+            };
+
+            // Detached: mutating after the snapshot must NOT change it.
+            const detached = makePopulatedStore();
+            const detachedSnapshot = detached.store.toData(true);
+            detached.store.update(detached.entity, { health: { current: 1, max: 100 } });
+            expect(restore(detachedSnapshot)).toBe(100);
+
+            // Live (default): the snapshot references live buffers, so a later
+            // mutation is visible through it — the behavior the `copy` flag fixes.
+            const live = makePopulatedStore();
+            const liveSnapshot = live.store.toData();
+            live.store.update(live.entity, { health: { current: 1, max: 100 } });
+            expect(restore(liveSnapshot)).toBe(1);
+        });
+
         it("should create new resources when restoring to store with additional resources", () => {
             // Create original store with only one resource
             const originalStore = createStore({ components: {

--- a/packages/data/src/ecs/store/public/create-store.ts
+++ b/packages/data/src/ecs/store/public/create-store.ts
@@ -340,7 +340,7 @@ export function createStore<
                 seedIndexFromArchetypes(idx);
             }
         },
-        toData: () => core.toData(),
+        toData: (copy = false) => core.toData(copy),
         fromData: (data: unknown) => {
             core.fromData(data);
             for (const [name, resourceSchema] of Object.entries(resourceSchemas)) {

--- a/packages/data/src/ecs/store/store.ts
+++ b/packages/data/src/ecs/store/store.ts
@@ -25,7 +25,14 @@ interface BaseStore<C extends object = never> {
         include: readonly Include[] | ReadonlySet<string>,
         options?: EntitySelectOptions<C & OptionalComponents, Pick<C & RequiredComponents & OptionalComponents, Include>>
     ): readonly Entity[];
-    toData(): unknown
+    /**
+     * Serialize the store to a plain snapshot. When `copy` is true the snapshot
+     * is detached from the live store (column/entity buffers are copied) so it
+     * remains valid after subsequent mutations; otherwise it references live
+     * buffers and is only valid until the next mutation. See `Database.toData()`
+     * for the bug this `copy` flag addresses for transient-bearing strategies.
+     */
+    toData(copy?: boolean): unknown
 }
 
 export interface ReadonlyStore<


### PR DESCRIPTION
## Summary

- Replaces the implicit `sync?: DatabaseSyncOptions` binary fork with an explicit `ConcurrencyStrategy` interface, making the reconciliation engine swappable at database construction time
- Adds `createImmediateConcurrency()` — lighter-weight strategy with no global rollback-and-replay cycle; designed as the base for external wrappers (e.g. a collaborative-editing layer)
- Adds `createRebaseReplayConcurrency(userId)` — existing optimistic rebase-replay protocol as a named strategy (replaces `sync: { userId }`)
- Adds `createRollForwardConcurrency(userId)` — a client-side collaborative-editing model that replays pending edits by re-applying captured post-image tuples (roll-forward) rather than re-executing transaction functions; present to prove the seam hosts a fundamentally different engine
- Extracts `createRebaseReplayApplier` so reconciliation logic is shared between the legacy `createReconcilingDatabase` API and the new strategy
- Fixes a `toData()` live-reference bug so replay strategies serialize a detached, committed-only snapshot

**Migration:** `createDatabase(plugin, { sync: { userId } })` → `createDatabase(plugin, { concurrency: createRebaseReplayConcurrency(userId) })`

See `packages/data/src/ecs/database/concurrency/README.md` for how to author a strategy.