### PR TITLE
feat(ecs): surface base-plugin computeds inside derived computed factories

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
+    "lint": "pnpm -r run lint",
+    "lint-fix": "pnpm -r run lint-fix",
+    "typecheck": "pnpm -r run typecheck",
     "dev": "pnpm -r --parallel run dev",
     "dev:data": "pnpm --filter @adobe/data run dev",
     "link": "pnpm -r --filter @adobe/data* run link",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.67",
+    "version": "0.9.68",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -18,7 +18,6 @@
         "build": "cp ../../LICENSE . 2>/dev/null || true; tsc -b",
         "clean": "rm -rf dist node_modules",
         "dev": "tsc -b -w --preserveWatchOutput",
-        "lint": "pnpm eslint .",
         "test": "pnpm exec playwright install chromium && vitest --run",
         "test:node": "vitest --run --project=node",
         "test:browser": "vitest --run --project=browser",

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.67",
+    "version": "0.9.68",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -18,7 +18,6 @@
         "build": "cp ../../LICENSE . 2>/dev/null || true; tsc -b",
         "clean": "rm -rf dist node_modules",
         "dev": "tsc -b -w --preserveWatchOutput",
-        "lint": "pnpm eslint .",
         "test": "vitest --run --project=node",
         "test:node": "vitest --run --project=node"
     },

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.67",
+  "version": "0.9.68",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/create-plugin.ts
+++ b/packages/data/src/ecs/database/create-plugin.ts
@@ -136,11 +136,16 @@ type FullDBForPlugin<
     S | StringKeyof<XP['systems']>,
     ToActionFunctions<AD & XP['actions']>,
     FromServiceFactories<RemoveIndex<SVF> & XP['services']>,
-    // 8: CV — placeholder. Kept `unknown` (Database's own default for this slot)
-    //    so a concrete computed-values type never constrains computed-factory
-    //    inference / breaks contravariance. Must be supplied explicitly because
-    //    slot 9 (IX) sits after it.
-    unknown,
+    // 8: CV — the base plugin's already-resolved computeds. XP is
+    //    AmbientPlugin<XP, IP> at the call sites, so XP['computed'] carries the
+    //    `extends` base + `imports` deps' computeds — all fully constructed, so
+    //    surfacing them here is sound (nothing in-progress, no circularity).
+    //    The current plugin's OWN computeds (CVF) are deliberately NOT a
+    //    parameter to this type, so they never flow into their own factory db:
+    //    a computed cannot reference an in-progress sibling, but it CAN compose
+    //    on a base plugin's computed with full types — same rule actions/systems
+    //    already follow. Resolves to `{}` for the common no-base-computeds case.
+    FromComputedFactories<XP['computed']>,
     // 9: IX — thread the index declarations so `db.indexes` is populated inside
     //    computed factories, same as the actions/systems `db` already does.
     //    XP is AmbientPlugin<XP, IP> at the call sites, so XP['indexes'] carries

--- a/packages/data/src/ecs/database/create-plugin.type-test.ts
+++ b/packages/data/src/ecs/database/create-plugin.type-test.ts
@@ -330,6 +330,72 @@ function validTypeInferenceTests() {
 }
 
 // ============================================================================
+// Standalone computed factories aggregated in a create call
+// ============================================================================
+//
+// A common app pattern: computed factories are authored as standalone
+// functions in their own files, then aggregated into one `computed: {}` block
+// in a single createPlugin call. Each standalone factory must annotate its
+// `db` parameter with a NAMED, exported type (it lives in a different module
+// from the plugin).
+//
+// Before the FullDBForPlugin fix the factory db's `computed` slot was
+// `unknown`, so the annotation had to strip it:
+//     type CoreStateDatabase = Omit<Database.Plugin.ToDatabase<typeof core>, 'computed'>;
+// Now the factory sees the base plugin's already-resolved computeds, so the
+// plain exported `Database.Plugin.ToDatabase<typeof core>` is the correct,
+// cast-free annotation — AND it lets a standalone factory compose on a base
+// computed. This test proves the round trip type-checks cleanly: no `as`, no
+// `Omit`, no `@ts-expect-error`.
+function standaloneComputedFactoryAggregation() {
+    // The base "state" plugin owns the resources and one base computed.
+    const coreStatePlugin = createPlugin({
+        resources: {
+            count: { default: 0 as number },
+        },
+        computed: {
+            count: (db) => db.observe.resources.count,
+        },
+    });
+
+    // The single exported alias every standalone factory annotates against.
+    type CoreStateDatabase = Database.Plugin.ToDatabase<typeof coreStatePlugin>;
+
+    // Standalone factory (own file): reads a base resource.
+    const doubled = (db: CoreStateDatabase) =>
+        Observe.withMap(db.observe.resources.count, (v) => v * 2);
+
+    // Standalone factory (own file): composes on the base plugin's computed.
+    // This is the case the fix unlocks — `db.computed.count` is fully typed.
+    const isPositive = (db: CoreStateDatabase) =>
+        Observe.withMap(db.computed.count, (v) => v > 0);
+
+    // Standalone factory (own file): a parameterized computed that also reads
+    // a base computed.
+    const atLeast = (db: CoreStateDatabase) => (min: number) =>
+        Observe.withMap(db.computed.count, (v) => v >= min);
+
+    // Aggregate the independently-authored factories into the derived plugin's
+    // computed block — clean assignment, no cast.
+    const derived = createPlugin({
+        extends: coreStatePlugin,
+        computed: {
+            doubled,
+            isPositive,
+            atLeast,
+        },
+    });
+
+    // The resulting plugin exposes the aggregated computeds with exact types,
+    // alongside the inherited base computed.
+    type DerivedComputed = Database.FromPlugin<typeof derived>['computed'];
+    type _CheckDoubled = Assert<Equal<DerivedComputed['doubled'], Observe<number>>>;
+    type _CheckIsPositive = Assert<Equal<DerivedComputed['isPositive'], Observe<boolean>>>;
+    type _CheckAtLeast = Assert<Equal<DerivedComputed['atLeast'], (min: number) => Observe<boolean>>>;
+    type _CheckInheritedCount = Assert<Equal<DerivedComputed['count'], Observe<number>>>;
+}
+
+// ============================================================================
 // INVALID TYPE INFERENCE TESTS
 // ============================================================================
 

--- a/packages/data/src/ecs/database/create-plugin.type-test.ts
+++ b/packages/data/src/ecs/database/create-plugin.type-test.ts
@@ -134,6 +134,30 @@ function validTypeInferenceTests() {
         },
     });
 
+    // Test: a derived plugin's computed factory can read a BASE plugin's
+    // already-resolved computed (composition across `extends`). This is the
+    // payoff of FullDBForPlugin surfacing FromComputedFactories<XP['computed']>
+    // rather than `unknown` in the computed-factory db.
+    const baseComputedPlugin = createPlugin({
+        resources: {
+            n: { default: 10 as number },
+        },
+        computed: {
+            doubled: (db) => Observe.withMap(db.observe.resources.n, (v) => v * 2),
+        },
+    });
+
+    const derivedComputedPlugin = createPlugin({
+        extends: baseComputedPlugin,
+        computed: {
+            quadrupled: (db) => {
+                // Valid - the base plugin's computed is fully typed here.
+                const base: Observe<number> = db.computed.doubled;
+                return Observe.withMap(base, (v) => v * 2);
+            },
+        },
+    });
+
     // Test: Computed + transactions co-inference
     // When both computed and transactions are defined in the same plugin,
     // TypeScript must infer TD from the transactions property independently
@@ -504,6 +528,23 @@ function invalidComputedReturnsObject() {
         transactions: {},
         actions: {},
         systems: {},
+    });
+}
+
+// Test: Invalid sibling computed access — an in-progress computed in the SAME
+// plugin is not visible to a sibling factory (would be circular). Only a
+// base plugin's already-resolved computeds are surfaced.
+function invalidSiblingComputedAccess() {
+    createPlugin({
+        resources: { n: { default: 1 as number } },
+        computed: {
+            first: (db) => Observe.fromConstant(db.resources.n),
+            second: (db) => {
+                // @ts-expect-error - sibling computed 'first' is in-progress, not visible
+                const _f = db.computed.first;
+                return Observe.fromConstant(0);
+            },
+        },
     });
 }
 

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -319,6 +319,33 @@ export namespace Database {
     export type ToDatabase<P extends Database.Plugin> = Database.FromPlugin<P>;
     export type ToStore<P extends Database.Plugin> = Store<FromSchemas<RemoveIndex<P['components']>>, FromSchemas<RemoveIndex<P['resources']>>, RemoveIndex<P['archetypes']>>;
     /**
+     * The database type seen *inside a computed factory* — same shape as
+     * `ToDatabase<P>` but with `computed: unknown`.
+     *
+     * Use this when aliasing the database for a module that doesn't consume
+     * `db.computed`, or anywhere `ToDatabase<P>` would force a dependency on
+     * the fully-resolved computed-values type and break inference:
+     *
+     * ```ts
+     * // ❌ hand-reconstructs the framework's contract
+     * type CoreStateDatabase = Omit<Database.Plugin.ToDatabase<typeof coreStatePlugin>, 'computed'>;
+     *
+     * // ✅ first-class contract
+     * type CoreStateDatabase = Database.Plugin.ToComputedDb<typeof coreStatePlugin>;
+     * ```
+     */
+    export type ToComputedDb<P extends Database.Plugin> = Database<
+      FromSchemas<RemoveIndex<P['components']>>,
+      FromSchemas<RemoveIndex<P['resources']>>,
+      RemoveIndex<P['archetypes']>,
+      ToTransactionFunctions<RemoveIndex<P['transactions']>>,
+      StringKeyof<P['systems']>,
+      ToActionFunctions<RemoveIndex<P['actions']>>,
+      FromServiceFactories<RemoveIndex<P['services']>>,
+      unknown,
+      RemoveIndex<P['indexes']>
+    >;
+    /**
      * The plugin's store as seen *inside a transaction body* — i.e. `ToStore<P>`
      * plus the `userId` field added by the transaction dispatcher. Use this
      * when typing helper functions that forward a transaction's store into

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -319,38 +319,6 @@ export namespace Database {
     export type ToDatabase<P extends Database.Plugin> = Database.FromPlugin<P>;
     export type ToStore<P extends Database.Plugin> = Store<FromSchemas<RemoveIndex<P['components']>>, FromSchemas<RemoveIndex<P['resources']>>, RemoveIndex<P['archetypes']>>;
     /**
-     * `ToDatabase<P>` with the computed surface erased (`computed: unknown`).
-     *
-     * Use this to alias a plugin's database in a context that must not depend
-     * on the fully-resolved computed-values type — e.g. to break a type cycle,
-     * or in a module that never reads `db.computed`. It replaces the hand-rolled
-     * `Omit` that reconstructs the same shape:
-     *
-     * ```ts
-     * // ❌ hand-reconstructs the framework's contract
-     * type CoreStateDatabase = Omit<Database.Plugin.ToDatabase<typeof coreStatePlugin>, 'computed'>;
-     *
-     * // ✅ first-class contract
-     * type CoreStateDatabase = Database.Plugin.ToComputedDb<typeof coreStatePlugin>;
-     * ```
-     *
-     * Note: this is *not* the db a computed factory receives. A factory of a
-     * plugin that `extends` a base sees that base's already-resolved computeds
-     * (so it can compose on them); the factory's own in-progress siblings stay
-     * hidden. When you want that fully-resolved surface, use `ToDatabase<P>`.
-     */
-    export type ToComputedDb<P extends Database.Plugin> = Database<
-      FromSchemas<RemoveIndex<P['components']>>,
-      FromSchemas<RemoveIndex<P['resources']>>,
-      RemoveIndex<P['archetypes']>,
-      ToTransactionFunctions<RemoveIndex<P['transactions']>>,
-      StringKeyof<P['systems']>,
-      ToActionFunctions<RemoveIndex<P['actions']>>,
-      FromServiceFactories<RemoveIndex<P['services']>>,
-      unknown,
-      RemoveIndex<P['indexes']>
-    >;
-    /**
      * The plugin's store as seen *inside a transaction body* — i.e. `ToStore<P>`
      * plus the `userId` field added by the transaction dispatcher. Use this
      * when typing helper functions that forward a transaction's store into

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -319,12 +319,12 @@ export namespace Database {
     export type ToDatabase<P extends Database.Plugin> = Database.FromPlugin<P>;
     export type ToStore<P extends Database.Plugin> = Store<FromSchemas<RemoveIndex<P['components']>>, FromSchemas<RemoveIndex<P['resources']>>, RemoveIndex<P['archetypes']>>;
     /**
-     * The database type seen *inside a computed factory* — same shape as
-     * `ToDatabase<P>` but with `computed: unknown`.
+     * `ToDatabase<P>` with the computed surface erased (`computed: unknown`).
      *
-     * Use this when aliasing the database for a module that doesn't consume
-     * `db.computed`, or anywhere `ToDatabase<P>` would force a dependency on
-     * the fully-resolved computed-values type and break inference:
+     * Use this to alias a plugin's database in a context that must not depend
+     * on the fully-resolved computed-values type — e.g. to break a type cycle,
+     * or in a module that never reads `db.computed`. It replaces the hand-rolled
+     * `Omit` that reconstructs the same shape:
      *
      * ```ts
      * // ❌ hand-reconstructs the framework's contract
@@ -333,6 +333,11 @@ export namespace Database {
      * // ✅ first-class contract
      * type CoreStateDatabase = Database.Plugin.ToComputedDb<typeof coreStatePlugin>;
      * ```
+     *
+     * Note: this is *not* the db a computed factory receives. A factory of a
+     * plugin that `extends` a base sees that base's already-resolved computeds
+     * (so it can compose on them); the factory's own in-progress siblings stay
+     * hidden. When you want that fully-resolved surface, use `ToDatabase<P>`.
      */
     export type ToComputedDb<P extends Database.Plugin> = Database<
       FromSchemas<RemoveIndex<P['components']>>,


### PR DESCRIPTION
## Description

`FullDBForPlugin` hardcoded the computed-factory `db`'s computed slot (`CV`) to `unknown`, which erased the `extends` / `imports` base's **already-resolved** computeds — not just the current plugin's in-progress ones. As a result, a derived plugin's computed factory could not compose on a base plugin's computed.

This PR sets that slot to `FromComputedFactories<XP['computed']>`. `XP` is `AmbientPlugin<XP, IP>` at the call sites, so it surfaces the base + imports computeds (all fully constructed — no circularity). The current plugin's own `CVF` is never a parameter to the type, so in-progress siblings stay hidden — the same rule actions/systems already follow.

```ts
const base = createPlugin({
  resources: { n: { default: 10 } },
  computed: { doubled: (db) => Observe.withMap(db.observe.resources.n, (v) => v * 2) },
});

const derived = createPlugin({
  extends: base,
  computed: {
    // now fully typed — previously db.computed was `unknown`
    quadrupled: (db) => Observe.withMap(db.computed.doubled, (v) => v * 2),
  },
});
```

### Also

- Added type-tests for both directions: base composition works; an in-progress sibling stays hidden.
- Dropped `Database.Plugin.ToComputedDb` (introduced earlier in this branch). It was a `computed: unknown` mirror of the old factory context; now that factories see the base's resolved computeds it no longer mirrors anything, and its residual "strip computed" use is a near-duplicate of `ToDatabase`. The rare call site can use `Omit<ToDatabase<P>, 'computed'>` inline.
- Version bump to 0.9.68.

## Verification

- `tsc -b` clean (incl. `@ts-expect-error` assertions in the new tests)
- `pnpm lint` clean
- Full `@adobe/data` suite: 2584 passed