### PR TITLE
feat(data-lit): add write-only service setter to DatabaseElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-lit/src/elements/database-element.ts
+++ b/packages/data-lit/src/elements/database-element.ts
@@ -10,21 +10,24 @@ import { attachDecorator, withHooks } from '../index.js';
 export abstract class DatabaseElement<P extends Database.Plugin> extends LitElement {
 
   /**
-   * The live database, fully typed. Set by an ancestor via DI (`.database=…`)
-   * or created from `plugin` on connect. Bootstrap containers — those that own
-   * a controller or drive a streaming (async-generator) transaction — read
-   * this directly; pure widgets use the restricted `service` view below.
+   * @internal DI seam. Set by an ancestor via injection or created from `plugin`
+   * on connect. Bootstrap containers (those that own a controller or drive a
+   * streaming async-generator transaction) and ancestor injection use this;
+   * ordinary consumers inject and read through `service` instead.
    */
   @property({ type: Object, reflect: false })
   database!: Database.Plugin.ToDatabase<P>;
 
   /**
-   * UI-restricted view of {@link database} for pure-widget rendering: every
-   * transaction / mutator is rewritten to fire-and-forget `void` so a widget
-   * can never await on or read back a mutation; reads go through `observe`.
+   * UI-restricted view of the database for rendering. Inject the full database by
+   * assigning here (`element.service = db`); reads return the restricted view where
+   * every mutator is fire-and-forget `void`.
    */
   get service(): UIService.FromService<Database.Plugin.ToDatabase<P>> {
     return UIService.restrict(this.database);
+  }
+  set service(db: Database.Plugin.ToDatabase<P>) {
+    this.database = db;
   }
 
   constructor() {

--- a/packages/data-lit/src/elements/database-element.type-test.ts
+++ b/packages/data-lit/src/elements/database-element.type-test.ts
@@ -37,6 +37,19 @@ class _CountElement extends DatabaseElement<typeof plugin> {
 type ServiceType = _CountElement["service"];
 type RawDatabase = Database.Plugin.ToDatabase<typeof plugin>;
 
+// 0. `service` is a read/write accessor: the getter returns the restricted view,
+//    while the setter accepts the full database (injection). The divergent
+//    get/set types are intentional (legal since TS 5.1).
+const _injectFullDatabase = (el: _CountElement, db: RawDatabase): void => {
+  el.service = db;
+};
+// A side effect of the divergence: `el.service = el.service` is a type error,
+// since the restricted getter type is not assignable to the full setter type.
+const _rejectRestrictedAssignment = (el: _CountElement): void => {
+  // @ts-expect-error restricted view is not assignable back to the full database
+  el.service = el.service;
+};
+
 // 1. The exposed service type is the UIService-restricted view of the database.
 type _CheckRestricted = Assert<Equal<ServiceType, UIService.FromService<RawDatabase>>>;
 

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.70",
+    "version": "0.9.71",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.70",
+    "version": "0.9.71",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Description

Make `service` the single public surface of `DatabaseElement`. Consumers inject the full database via `.service=` and read a restricted `UIService` view via `.service`.

- Added a `set service(db)` that forwards to `database`, so `.service=${db}` works in Lit templates and passes lit-analyzer's `no-unknown-property`.
- The divergent get/set types are intentional (legal since TS 5.1): the setter takes the full `Database` (injection); the getter returns the restricted `UIService.FromService` view. A side effect — `el.service = el.service` is a type error — is expected and asserted in the type test.
- `database` stays a public `@property` (Lit needs it public to bind/observe, and `findAncestorDatabase` duck-types `element.database` across instances) but is now documented `@internal`.
- `findAncestorDatabase` continues to read `.database`, not `.service`, so ancestor DI threads the genuine database regardless of what `restrict` does at runtime.

Updated `database-element.type-test.ts` to assert the setter accepts the full database type and the getter returns the restricted type.

## Related PRs

_None_