### PR TITLE
ci: gate all packages + fix stripped database .d.ts (red/green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,13 @@ jobs:
       - name: Build @adobe/data (provides dist/ for downstream tsc)
         run: pnpm --filter @adobe/data run typecheck
 
-      - name: Build downstream packages (type-check via tsc -b)
-        run: pnpm --filter '@adobe/data-*' run build
+      - name: Build every downstream package (type-check via tsc -b / vite)
+        # Builds ALL workspace packages except the core (already built above),
+        # including the private, unscoped sample apps (data-p2p-tictactoe,
+        # data-lit-todo, …). A previous `--filter '@adobe/data-*'` only matched
+        # scoped published packages, so a type/build error that surfaced only in
+        # a private sample (e.g. a stripped `.d.ts` member) merged green.
+        run: pnpm --filter '!@adobe/data' run build
 
       - name: Test downstream packages
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-lit/src/elements/database-element.ts
+++ b/packages/data-lit/src/elements/database-element.ts
@@ -10,10 +10,17 @@ import { attachDecorator, withHooks } from '../index.js';
 export abstract class DatabaseElement<P extends Database.Plugin> extends LitElement {
 
   /**
-   * @internal DI seam. Set by an ancestor via injection or created from `plugin`
-   * on connect. Bootstrap containers (those that own a controller or drive a
-   * streaming async-generator transaction) and ancestor injection use this;
-   * ordinary consumers inject and read through `service` instead.
+   * Internal DI seam — prefer `service`. Set by an ancestor via injection or
+   * created from `plugin` on connect. Bootstrap containers (those that own a
+   * controller or drive a streaming async-generator transaction) and ancestor
+   * injection use this; ordinary consumers inject and read through `service`
+   * instead.
+   *
+   * Deliberately documented in prose rather than with the internal JSDoc tag:
+   * this package emits with `stripInternal`, so that tag would erase this
+   * declaration from the public `.d.ts`. It must survive because
+   * `findAncestorDatabase` duck-types `element.database` across instances and
+   * bootstrap subclasses read it directly.
    */
   @property({ type: Object, reflect: false })
   database!: Database.Plugin.ToDatabase<P>;

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.71",
+    "version": "0.9.72",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.71",
+    "version": "0.9.72",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Description

Two compounding gaps let the `database` `.d.ts` regression merge green in #131:

1. **CI build coverage** — the `packages` job filtered `@adobe/data-*`, matching only scoped *published* packages. The break surfaced only in `data-p2p-tictactoe` (private, unscoped), which CI never built.
2. **Required checks** — only the `data` job is a required status check; the `packages` job isn't, so even a red downstream build wouldn't block merge.

This PR is staged as a **red/green test of the gate**:

- **Commit 1 (red):** widen the CI build to every workspace package. With main's stripped-`database` regression still present, CI should now build `data-p2p-tictactoe` and go **red**.
- **Commit 2 (green):** apply the real fix (document the DI seam in prose instead of `@internal`, which `stripInternal` was erasing from the public `.d.ts`) + version bump. CI back to **green**.

Making the `packages` job a *required* check (gap 2) is a branch-protection change tracked separately.

## Related PRs

- Follow-up to #131 (which introduced the regression)