### PR TITLE
feat(data-ai): cross-agent skill bundle + installer + Claude plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "adobe-data-skills",
+  "owner": {
+    "name": "Adobe"
+  },
+  "plugins": [
+    {
+      "name": "adobe-data-ai",
+      "source": "./packages/data-ai",
+      "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",
@@ -12,7 +12,7 @@
     "dev:data": "pnpm --filter @adobe/data run dev",
     "dev-gpu": "pnpm --parallel --filter @adobe/data --filter @adobe/data-gpu --filter data-gpu-samples run dev",
     "link": "pnpm -r --filter @adobe/data* run link",
-    "publish": "sh -c 'for x in \"$@\"; do OTP=\"$x\"; done; export NPM_CONFIG_OTP=\"$OTP\"; pnpm -r --filter @adobe/data --filter @adobe/data-react --filter @adobe/data-lit --filter @adobe/data-solid --filter @adobe/data-gpu run publish-public' sh",
+    "publish": "sh -c 'for x in \"$@\"; do OTP=\"$x\"; done; export NPM_CONFIG_OTP=\"$OTP\"; pnpm -r --filter @adobe/data --filter @adobe/data-ai --filter @adobe/data-react --filter @adobe/data-lit --filter @adobe/data-solid --filter @adobe/data-gpu run publish-public' sh",
     "bump": "pnpm version patch --no-git-tag-version && V=$(node -p \"require('$PWD/package.json').version\") && pnpm -r exec pnpm version $V --no-git-tag-version --allow-same-version",
     "release": "pnpm bump && pnpm publish",
     "bp": "pnpm bump && pnpm run publish"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "adobe-data-ai",
+  "version": "0.9.74",
+  "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
+  "author": {
+    "name": "Adobe"
+  }
+}

--- a/packages/data-ai/LICENSE
+++ b/packages/data-ai/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Adobe, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/data-ai/README.md
+++ b/packages/data-ai/README.md
@@ -1,3 +1,66 @@
+# @adobe/data-ai
+
+Cross-agent architecture skills for [`@adobe/data`](https://www.npmjs.com/package/@adobe/data). One skill bundle, authored once, distributed two ways.
+
+Skills version in lockstep with the library: `@adobe/data-ai@x.y.z` describes `@adobe/data@x.y.z`.
+
+## Install (any agent)
+
+The installer copies the flat skill folders into whichever skill roots your project's agents scan. It is idempotent and version-stamped — commit the result, and re-run to refresh.
+
+```sh
+npx @adobe/data-ai@latest install
+```
+
+This writes:
+
+| Root | Agent | Notes |
+| --- | --- | --- |
+| `.claude/skills/<name>/` | Claude Code | No recursion — skills must be flat. |
+| `.agents/skills/<name>/` | Cursor, Codex | Tool-neutral; other Agent-Skills agents pick these up. |
+
+Options:
+
+```sh
+npx @adobe/data-ai@latest install --claude     # only .claude/skills
+npx @adobe/data-ai@latest install --agents     # only .agents/skills (alias: --cursor)
+npx @adobe/data-ai@latest install --global      # into ~/.claude, ~/.agents
+npx @adobe/data-ai@latest install --dir=./sub   # into a specific base dir
+npx @adobe/data-ai@latest list                  # show bundled skills
+```
+
+Each root gets a `.data-ai.json` manifest recording which skills this package owns, so a re-run prunes skills we no longer ship without touching skills you added yourself.
+
+## Install (Claude Code plugin)
+
+Claude users can instead consume the skills as a native plugin from the `adobe/data` marketplace — no npm needed.
+
+Interactive:
+
+```
+/plugin marketplace add adobe/data
+/plugin install adobe-data-ai@adobe-data-skills
+```
+
+Or declaratively, so collaborators are prompted to auto-install on next launch — commit to your repo's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "adobe-data-skills": {
+      "source": { "source": "github", "repo": "adobe/data" }
+    }
+  },
+  "enabledPlugins": {
+    "adobe-data-ai@adobe-data-skills": true
+  }
+}
+```
+
+The plugin cache is version-hashed and garbage-collected, so it is not a stable path to symlink against — prefer the `npx … install` copy model when you need a durable, cross-agent artifact.
+
+---
+
 # Pragmatic Programming
 
 ## Target Audience

--- a/packages/data-ai/bin/cli.mjs
+++ b/packages/data-ai/bin/cli.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Installer for the @adobe/data-ai skill bundle.
+//
+// Copies the flat SKILL.md folders shipped in this package into whichever
+// agent-skill roots the consuming project scans, so the same authored-once
+// bundle works across Claude Code, Cursor, and Codex:
+//
+//   .claude/skills/<name>/   Claude Code   (no recursion — flat is required)
+//   .agents/skills/<name>/   Cursor, Codex (tool-neutral, future agents)
+//
+// The copy is durable and committable; re-run to refresh to a new version.
+// Ownership is tracked per root in a `.data-ai.json` manifest so re-runs
+// prune skills this package no longer ships without touching skills you added.
+
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "..");
+const skillsSrc = join(pkgRoot, "skills");
+const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
+const { name: PKG_NAME, version: VERSION } = pkg;
+
+// Each target agent's skills root, relative to a base directory.
+const ROOTS = {
+    claude: (base) => join(base, ".claude", "skills"),
+    agents: (base) => join(base, ".agents", "skills"),
+};
+
+function discoverSkills() {
+    if (!existsSync(skillsSrc)) return [];
+    return readdirSync(skillsSrc, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && existsSync(join(skillsSrc, d.name, "SKILL.md")))
+        .map((d) => d.name)
+        .sort();
+}
+
+function installTo(rootDir, skills) {
+    mkdirSync(rootDir, { recursive: true });
+    const manifestPath = join(rootDir, ".data-ai.json");
+
+    // Prune skills we previously owned but no longer ship.
+    if (existsSync(manifestPath)) {
+        try {
+            const prev = JSON.parse(readFileSync(manifestPath, "utf8"));
+            for (const name of prev.skills ?? []) {
+                if (!skills.includes(name) && existsSync(join(rootDir, name))) {
+                    rmSync(join(rootDir, name), { recursive: true, force: true });
+                }
+            }
+        } catch {
+            // Unreadable manifest — ignore and re-stamp below.
+        }
+    }
+
+    for (const name of skills) {
+        const dest = join(rootDir, name);
+        rmSync(dest, { recursive: true, force: true });
+        cpSync(join(skillsSrc, name), dest, { recursive: true });
+    }
+
+    writeFileSync(
+        manifestPath,
+        JSON.stringify({ package: PKG_NAME, version: VERSION, skills }, null, 2) + "\n",
+    );
+}
+
+function parseArgs(argv) {
+    const positional = [];
+    const flags = new Set();
+    let dir = null;
+    for (const a of argv) {
+        if (a === "--global" || a === "-g") flags.add("global");
+        else if (a === "--claude") flags.add("claude");
+        else if (a === "--agents" || a === "--cursor") flags.add("agents");
+        else if (a === "--help" || a === "-h") flags.add("help");
+        else if (a.startsWith("--dir=")) dir = a.slice("--dir=".length);
+        else if (!a.startsWith("-")) positional.push(a);
+    }
+    return { cmd: positional[0] ?? "install", flags, dir };
+}
+
+const HELP = `${PKG_NAME} v${VERSION}
+
+Install cross-agent architecture skills into the current project.
+
+Usage:
+  npx ${PKG_NAME}@latest install [options]
+  npx ${PKG_NAME}@latest list
+
+Commands:
+  install   Copy skills into the project's agent-skill roots (default).
+  list      Print the skills bundled in this package.
+
+Options:
+  --claude        Install only into .claude/skills/
+  --agents        Install only into .agents/skills/ (Cursor, Codex)
+  --cursor        Alias for --agents
+  --global, -g    Install into your home directory (~/.claude, ~/.agents)
+                  instead of the current project.
+  --dir=<path>    Base directory to install into (default: cwd).
+  --help, -h      Show this help.
+
+With no target flag, installs into both .claude/skills and .agents/skills.
+`;
+
+function main() {
+    const { cmd, flags, dir } = parseArgs(process.argv.slice(2));
+
+    if (flags.has("help") || cmd === "help") {
+        process.stdout.write(HELP);
+        return;
+    }
+
+    const skills = discoverSkills();
+
+    if (cmd === "list") {
+        process.stdout.write(`${PKG_NAME} v${VERSION} bundles ${skills.length} skill(s):\n`);
+        for (const s of skills) process.stdout.write(`  - ${s}\n`);
+        return;
+    }
+
+    if (cmd !== "install") {
+        process.stderr.write(`Unknown command: ${cmd}\n\n${HELP}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    if (skills.length === 0) {
+        process.stderr.write(`No skills found in ${skillsSrc}\n`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const base = flags.has("global") ? homedir() : dir ? resolve(dir) : process.cwd();
+
+    const chosen = [];
+    if (flags.has("claude")) chosen.push("claude");
+    if (flags.has("agents")) chosen.push("agents");
+    if (chosen.length === 0) chosen.push("claude", "agents");
+
+    process.stdout.write(`Installing ${skills.length} skill(s) from ${PKG_NAME} v${VERSION}\n`);
+    for (const key of chosen) {
+        const rootDir = ROOTS[key](base);
+        installTo(rootDir, skills);
+        process.stdout.write(`  ${rootDir}\n`);
+    }
+    process.stdout.write(`Skills: ${skills.join(", ")}\n`);
+}
+
+main();

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,23 +1,39 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.54",
-  "description": "Claude and AI-assistant rules and guidance for Adobe data-oriented architecture",
+  "version": "0.9.74",
+  "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
+  "type": "module",
   "private": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "bin": {
+    "data-ai": "bin/cli.mjs"
+  },
   "files": [
+    "skills",
+    "bin",
+    ".claude-plugin",
     "README.md",
-    "LICENSE",
-    ".claude"
+    "LICENSE"
   ],
   "scripts": {
     "build": "cp ../../LICENSE .",
     "test": "vitest --run --passWithNoTests",
     "publish-public": "pnpm build && pnpm publish --no-git-checks --access public"
   },
+  "keywords": [
+    "adobe",
+    "data",
+    "agent-skills",
+    "claude-code",
+    "cursor",
+    "codex",
+    "skills"
+  ],
   "devDependencies": {
     "vitest": "^1.6.0"
-  }
+  },
+  "license": "MIT"
 }

--- a/packages/data-ai/skills/bar/SKILL.md
+++ b/packages/data-ai/skills/bar/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: bar
+description: Sample skill that greets bar. Placeholder demonstrating the @adobe/data-ai skill-bundle wiring; replace with a real architecture skill.
+---
+
+# bar
+
+Say "hello bar".

--- a/packages/data-ai/skills/foo/SKILL.md
+++ b/packages/data-ai/skills/foo/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: foo
+description: Sample skill that greets foo. Placeholder demonstrating the @adobe/data-ai skill-bundle wiring; replace with a real architecture skill.
+---
+
+# foo
+
+Say "hello foo".

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.73",
+    "version": "0.9.74",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.73",
+    "version": "0.9.74",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.73",
+  "version": "0.9.74",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,12 @@ importers:
         specifier: ^9.0.9
         version: 9.29.1
 
+  packages/data-ai:
+    devDependencies:
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@25.9.4)(@vitest/browser@1.6.1)(jsdom@24.1.3)
+
   packages/data-gpu:
     dependencies:
       '@adobe/data':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'packages/data'
+  - 'packages/data-ai'
   - 'packages/data-persistence'
   - 'packages/data-sync'
   - 'packages/data-lit'


### PR DESCRIPTION
## Description

Turns `@adobe/data-ai` into a real, publishable **cross-agent architecture-skill bundle** with two distribution channels from this one monorepo subpackage.

**One flat `SKILL.md` bundle, distributed two ways:**

1. **npm installer (all agents)** — `npx @adobe/data-ai@latest install` copies the flat skill folders into `.claude/skills/` (Claude Code — no recursion) and `.agents/skills/` (Cursor, Codex). Idempotent and version-stamped: a per-root `.data-ai.json` manifest records ownership, so re-runs prune skills we stop shipping without touching skills you added. Durable + committable, unlike the version-hashed/GC'd plugin cache.
2. **Native Claude plugin** — repo-root `.claude-plugin/marketplace.json` lists the `adobe-data-ai` plugin at `./packages/data-ai`. Install via `/plugin marketplace add adobe/data` + `/plugin install adobe-data-ai@adobe-data-skills`, or commit the `extraKnownMarketplaces`/`enabledPlugins` snippet for team auto-install. Same `skills/` folder feeds both channels.

**What's here:**
- `packages/data-ai/bin/cli.mjs` — dependency-free installer (`install`, `list`, `--claude`/`--agents`/`--global`/`--dir=`).
- `packages/data-ai/skills/{foo,bar}` — placeholder sample skills; real architecture skills land in follow-ups.
- `.claude-plugin/marketplace.json` + `packages/data-ai/.claude-plugin/plugin.json`.
- Wired into `pnpm-workspace.yaml` and the root `publish` filter (was an un-workspaced orphan); version aligned to the unified bump so skills stay pinned to the `@adobe/data` release they describe.

**Notes:**
- The `pnpm-lock.yaml` diff is exactly the 6-line `data-ai` importer — regenerated with pnpm 10 to avoid the lockfile-version downgrade an older local pnpm would introduce.
- Lint + typecheck pass across all 15 buildable packages.

## Related PRs

_None._