### PR TITLE
fix(data-ai): install only into .agents/skills/adobe-data-ai, never .claude

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/README.md
+++ b/packages/data-ai/README.md
@@ -4,36 +4,32 @@ Cross-agent architecture skills for [`@adobe/data`](https://www.npmjs.com/packag
 
 Skills version in lockstep with the library: `@adobe/data-ai@x.y.z` describes `@adobe/data@x.y.z`.
 
-## Install (any agent)
+There are two distribution paths, one per agent family — they do **not** overlap:
 
-The installer copies the flat skill folders into whichever skill roots your project's agents scan. It is idempotent and version-stamped — commit the result, and re-run to refresh.
+- **Claude Code → marketplace plugin** (see below). The installer never writes into `.claude/skills/`, so it can't collide with your own Claude skills.
+- **Cursor / Codex / other `.agents`-standard agents → `npx … install`** (below).
+
+## Install (Cursor, Codex, `.agents` agents)
+
+The installer copies the skill folders into a single namespaced bundle directory that agents which recurse `.agents/skills/` discover:
 
 ```sh
 npx @adobe/data-ai@latest install
 ```
 
-This writes:
-
-| Root | Agent | Notes |
-| --- | --- | --- |
-| `.claude/skills/<name>/` | Claude Code | No recursion — skills must be flat. |
-| `.agents/skills/<name>/` | Cursor, Codex | Tool-neutral; other Agent-Skills agents pick these up. |
+This writes `.agents/skills/adobe-data-ai/<name>/SKILL.md` for each skill. The whole `adobe-data-ai/` directory belongs to this package, so a re-run is a clean wipe-and-recopy that never touches skills you authored elsewhere. Commit the result to share it with your team.
 
 Options:
 
 ```sh
-npx @adobe/data-ai@latest install --claude     # only .claude/skills
-npx @adobe/data-ai@latest install --agents     # only .agents/skills (alias: --cursor)
-npx @adobe/data-ai@latest install --global      # into ~/.claude, ~/.agents
-npx @adobe/data-ai@latest install --dir=./sub   # into a specific base dir
-npx @adobe/data-ai@latest list                  # show bundled skills
+npx @adobe/data-ai@latest install --global      # into ~/.agents/skills/adobe-data-ai/
+npx @adobe/data-ai@latest install --dir=./sub    # into a specific base dir
+npx @adobe/data-ai@latest list                   # show bundled skills
 ```
-
-Each root gets a `.data-ai.json` manifest recording which skills this package owns, so a re-run prunes skills we no longer ship without touching skills you added yourself.
 
 ## Install (Claude Code plugin)
 
-Claude users can instead consume the skills as a native plugin from the `adobe/data` marketplace — no npm needed.
+Claude Code does not scan `.agents/`; it consumes the skills as a native plugin from the `adobe/data` marketplace — no npm needed.
 
 Interactive:
 

--- a/packages/data-ai/bin/cli.mjs
+++ b/packages/data-ai/bin/cli.mjs
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
-// Installer for the @adobe/data-ai skill bundle.
+// Installer for the @adobe/data-ai skill bundle (Cursor / Codex / .agents-standard agents).
 //
-// Copies the flat SKILL.md folders shipped in this package into whichever
-// agent-skill roots the consuming project scans, so the same authored-once
-// bundle works across Claude Code, Cursor, and Codex:
+// Copies the SKILL.md folders shipped in this package into a single namespaced
+// bundle directory that agents which recurse `.agents/skills/` will discover:
 //
-//   .claude/skills/<name>/   Claude Code   (no recursion — flat is required)
-//   .agents/skills/<name>/   Cursor, Codex (tool-neutral, future agents)
+//   .agents/skills/adobe-data-ai/<name>/SKILL.md
 //
-// The copy is durable and committable; re-run to refresh to a new version.
-// Ownership is tracked per root in a `.data-ai.json` manifest so re-runs
-// prune skills this package no longer ships without touching skills you added.
+// We own the `adobe-data-ai/` directory outright, so a refresh is a clean
+// wipe-and-recopy — it never touches skills you authored elsewhere.
+//
+// Claude Code is intentionally NOT a target: it does not scan `.agents/`, and
+// copying into `.claude/skills/` could collide with a user's own skills.
+// Claude consumes these as the `adobe-data-ai` marketplace plugin instead
+// (see README).
 
 import {
     cpSync,
@@ -31,11 +33,8 @@ const skillsSrc = join(pkgRoot, "skills");
 const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
 const { name: PKG_NAME, version: VERSION } = pkg;
 
-// Each target agent's skills root, relative to a base directory.
-const ROOTS = {
-    claude: (base) => join(base, ".claude", "skills"),
-    agents: (base) => join(base, ".agents", "skills"),
-};
+// Namespaced bundle folder — the whole directory belongs to this package.
+const BUNDLE = "adobe-data-ai";
 
 function discoverSkills() {
     if (!existsSync(skillsSrc)) return [];
@@ -45,32 +44,15 @@ function discoverSkills() {
         .sort();
 }
 
-function installTo(rootDir, skills) {
-    mkdirSync(rootDir, { recursive: true });
-    const manifestPath = join(rootDir, ".data-ai.json");
-
-    // Prune skills we previously owned but no longer ship.
-    if (existsSync(manifestPath)) {
-        try {
-            const prev = JSON.parse(readFileSync(manifestPath, "utf8"));
-            for (const name of prev.skills ?? []) {
-                if (!skills.includes(name) && existsSync(join(rootDir, name))) {
-                    rmSync(join(rootDir, name), { recursive: true, force: true });
-                }
-            }
-        } catch {
-            // Unreadable manifest — ignore and re-stamp below.
-        }
-    }
-
+function installTo(bundleDir, skills) {
+    // We own this directory — wipe and recopy for a clean refresh.
+    rmSync(bundleDir, { recursive: true, force: true });
+    mkdirSync(bundleDir, { recursive: true });
     for (const name of skills) {
-        const dest = join(rootDir, name);
-        rmSync(dest, { recursive: true, force: true });
-        cpSync(join(skillsSrc, name), dest, { recursive: true });
+        cpSync(join(skillsSrc, name), join(bundleDir, name), { recursive: true });
     }
-
     writeFileSync(
-        manifestPath,
+        join(bundleDir, ".data-ai.json"),
         JSON.stringify({ package: PKG_NAME, version: VERSION, skills }, null, 2) + "\n",
     );
 }
@@ -81,8 +63,6 @@ function parseArgs(argv) {
     let dir = null;
     for (const a of argv) {
         if (a === "--global" || a === "-g") flags.add("global");
-        else if (a === "--claude") flags.add("claude");
-        else if (a === "--agents" || a === "--cursor") flags.add("agents");
         else if (a === "--help" || a === "-h") flags.add("help");
         else if (a.startsWith("--dir=")) dir = a.slice("--dir=".length);
         else if (!a.startsWith("-")) positional.push(a);
@@ -92,26 +72,22 @@ function parseArgs(argv) {
 
 const HELP = `${PKG_NAME} v${VERSION}
 
-Install cross-agent architecture skills into the current project.
+Install the architecture-skill bundle for Cursor, Codex, and other agents
+that scan .agents/skills/. (Claude Code uses the marketplace plugin instead.)
 
 Usage:
   npx ${PKG_NAME}@latest install [options]
   npx ${PKG_NAME}@latest list
 
 Commands:
-  install   Copy skills into the project's agent-skill roots (default).
+  install   Copy skills into .agents/skills/${BUNDLE}/ (default).
   list      Print the skills bundled in this package.
 
 Options:
-  --claude        Install only into .claude/skills/
-  --agents        Install only into .agents/skills/ (Cursor, Codex)
-  --cursor        Alias for --agents
-  --global, -g    Install into your home directory (~/.claude, ~/.agents)
+  --global, -g    Install into your home directory (~/.agents/skills/${BUNDLE}/)
                   instead of the current project.
   --dir=<path>    Base directory to install into (default: cwd).
   --help, -h      Show this help.
-
-With no target flag, installs into both .claude/skills and .agents/skills.
 `;
 
 function main() {
@@ -143,18 +119,12 @@ function main() {
     }
 
     const base = flags.has("global") ? homedir() : dir ? resolve(dir) : process.cwd();
+    const bundleDir = join(base, ".agents", "skills", BUNDLE);
 
-    const chosen = [];
-    if (flags.has("claude")) chosen.push("claude");
-    if (flags.has("agents")) chosen.push("agents");
-    if (chosen.length === 0) chosen.push("claude", "agents");
+    installTo(bundleDir, skills);
 
-    process.stdout.write(`Installing ${skills.length} skill(s) from ${PKG_NAME} v${VERSION}\n`);
-    for (const key of chosen) {
-        const rootDir = ROOTS[key](base);
-        installTo(rootDir, skills);
-        process.stdout.write(`  ${rootDir}\n`);
-    }
+    process.stdout.write(`Installed ${skills.length} skill(s) from ${PKG_NAME} v${VERSION}\n`);
+    process.stdout.write(`  ${bundleDir}\n`);
     process.stdout.write(`Skills: ${skills.join(", ")}\n`);
 }
 

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.74",
+    "version": "0.9.75",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.74",
+    "version": "0.9.75",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Description

Corrects the `@adobe/data-ai` installer to match the plan of record. The initial version (#136) copied flat skill folders into **both** `.claude/skills/` and `.agents/skills/`, which was never the intent.

**What changed:**
- The installer now copies into a single namespaced bundle directory — `.agents/skills/adobe-data-ai/<name>/SKILL.md` — that Cursor/Codex and other `.agents`-standard agents discover via recursion.
- It **owns** that `adobe-data-ai/` directory outright, so a refresh is a clean wipe-and-recopy that never touches skills you authored elsewhere.
- It **no longer writes into `.claude/skills/`** at all. That path risked stomping a user's own Claude skills. Claude Code — which doesn't scan `.agents/` — consumes these as the `adobe-data-ai` marketplace plugin instead (unchanged).
- Dropped the now-irrelevant `--claude` / `--agents` target flags; updated the README to document the two non-overlapping paths.

Verified: install writes only `.agents/skills/adobe-data-ai/{foo,bar}/SKILL.md`, and a pre-existing `.claude/skills/mine` is left untouched.

## Related PRs

- #136 (introduced the package; this corrects its install target)