### PR TITLE
feat(schema): add FromArchetype and FromComponents builders

### DIFF
--- a/packages/data/src/schema/from-archetype.ts
+++ b/packages/data/src/schema/from-archetype.ts
@@ -1,0 +1,30 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { Schema } from "./schema.js";
+import { FromComponents } from "./from-components.js";
+
+type PickComponents<
+  C extends { readonly [K in string]: Schema },
+  A extends readonly (string & keyof C)[],
+> = { readonly [K in A[number]]: C[K] };
+
+function pickComponents<
+  const C extends { readonly [K in string]: Schema },
+  const A extends readonly (string & keyof C)[],
+>(components: C, keys: A): PickComponents<C, A> {
+  return Object.fromEntries(
+    keys.map(key => [key, components[key]]),
+  ) as PickComponents<C, A>;
+}
+
+export type FromArchetype<
+  C extends { readonly [K in string]: Schema },
+  A extends readonly (string & keyof C)[],
+> = FromComponents<PickComponents<C, A>, A>;
+
+export function FromArchetype<
+  const C extends { readonly [K in string]: Schema },
+  const A extends readonly (string & keyof C)[],
+>(components: C, archetype: A): FromArchetype<C, A> {
+  return FromComponents(pickComponents(components, archetype), archetype);
+}

--- a/packages/data/src/schema/from-components.test.ts
+++ b/packages/data/src/schema/from-components.test.ts
@@ -1,0 +1,57 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { describe, expect, it } from "vitest";
+import { Schema } from "./index.js";
+
+describe("Schema.FromComponents", () => {
+  const componentSchemas = {
+    foo: { type: "string" },
+    bar: { type: "number" },
+  } as const;
+
+  it("builds an object schema with explicit required order", () => {
+    expect(Schema.FromComponents(componentSchemas, ["foo", "bar"])).toEqual({
+      type: "object",
+      properties: componentSchemas,
+      required: ["foo", "bar"],
+    });
+  });
+
+  it("defaults required to component keys when omitted", () => {
+    const schema = Schema.FromComponents(componentSchemas);
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: componentSchemas,
+      required: ["foo", "bar"],
+    });
+  });
+});
+
+describe("Schema.FromArchetype", () => {
+  const components = {
+    foo: { type: "string" },
+    bar: { type: "number" },
+    baz: { type: "boolean" },
+  } as const;
+
+  it("picks only archetype components and preserves order", () => {
+    expect(Schema.FromArchetype(components, ["baz", "foo"])).toEqual({
+      type: "object",
+      properties: {
+        baz: { type: "boolean" },
+        foo: { type: "string" },
+      },
+      required: ["baz", "foo"],
+    });
+  });
+
+  it("does not include components outside the archetype", () => {
+    const schema = Schema.FromArchetype(components, ["bar"]);
+
+    expect(schema.properties).toEqual({ bar: { type: "number" } });
+    expect(schema.required).toEqual(["bar"]);
+    expect(schema.properties).not.toHaveProperty("foo");
+    expect(schema.properties).not.toHaveProperty("baz");
+  });
+});

--- a/packages/data/src/schema/from-components.ts
+++ b/packages/data/src/schema/from-components.ts
@@ -1,0 +1,32 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { Schema } from "./schema.js";
+
+export type FromComponents<
+  P extends { readonly [K in string]: Schema },
+  R extends readonly (keyof P & string)[],
+> = {
+  readonly type: "object";
+  readonly properties: P;
+  readonly required: R;
+};
+
+export function FromComponents<
+  const P extends { readonly [K in string]: Schema },
+  const R extends readonly (keyof P & string)[],
+>(components: P, required: R): FromComponents<P, R>;
+
+export function FromComponents<
+  const P extends { readonly [K in string]: Schema },
+>(components: P): FromComponents<P, readonly (keyof P & string)[]>;
+
+export function FromComponents<
+  const P extends { readonly [K in string]: Schema },
+  const R extends readonly (keyof P & string)[],
+>(components: P, required?: R) {
+  return {
+    type: "object",
+    properties: components,
+    required: required ?? Object.keys(components),
+  } as const satisfies Schema;
+}

--- a/packages/data/src/schema/from-components.type-test.ts
+++ b/packages/data/src/schema/from-components.type-test.ts
@@ -1,0 +1,143 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+//
+// Compile-time type checks for Schema.FromComponents and Schema.FromArchetype.
+// Compiled by tsc (not vitest). Each check is isolated in its own function so
+// a failure in one does not degrade inference for the others.
+
+import { U32, Vec3 } from "../math/index.js";
+import type { Assert } from "../types/assert.js";
+import type { Equal } from "../types/equal.js";
+import { Schema } from "./index.js";
+
+const components = {
+  foo: { type: "string" },
+  bar: { type: "number" },
+  baz: { type: "boolean" },
+} as const;
+
+function fromComponentsWithRequiredTuple() {
+  const schema = Schema.FromComponents(
+    { a: Vec3.schema, b: U32.schema },
+    ["a", "b"],
+  );
+
+  type _Type = Assert<Equal<typeof schema.type, "object">>;
+  type _Properties = Assert<Equal<
+    typeof schema.properties,
+    { readonly a: typeof Vec3.schema; readonly b: typeof U32.schema }
+  >>;
+  type _RequiredIsTuple = Assert<Equal<typeof schema.required, readonly ["a", "b"]>>;
+  type _RequiredIsNotUnionArray = Assert<
+    Equal<(typeof schema.required)[number], "a" | "b">
+  >;
+}
+
+function fromComponentsWithoutRequired() {
+  const schema = Schema.FromComponents({ a: Vec3.schema, b: U32.schema });
+
+  type _Properties = Assert<Equal<
+    typeof schema.properties,
+    { readonly a: typeof Vec3.schema; readonly b: typeof U32.schema }
+  >>;
+  type _RequiredKeys = Assert<
+    Equal<(typeof schema.required)[number], "a" | "b">
+  >;
+}
+
+function fromArchetypePicksComponents() {
+  const schema = Schema.FromArchetype(components, ["foo", "baz"]);
+
+  type _Properties = Assert<Equal<
+    typeof schema.properties,
+    {
+      readonly foo: { readonly type: "string" };
+      readonly baz: { readonly type: "boolean" };
+    }
+  >>;
+  type _RequiredIsTuple = Assert<Equal<typeof schema.required, readonly ["foo", "baz"]>>;
+  type _BarIsExcluded = Assert<
+    Equal<"bar" extends keyof typeof schema.properties ? true : false, false>
+  >;
+}
+
+function fromArchetypeTypeAliasMatchesReturnType() {
+  const schema = Schema.FromArchetype(components, ["bar", "foo"]);
+
+  type Expected = Schema.FromArchetype<typeof components, readonly ["bar", "foo"]>;
+  type _Alias = Assert<Equal<typeof schema, Expected>>;
+}
+
+function fromArchetypeToTypeHasOnlyArchetypeKeys() {
+  const schema = Schema.FromArchetype(components, ["foo", "bar"]);
+  type T = Schema.ToType<typeof schema>;
+
+  type _ExactKeys = Assert<Equal<keyof T, "foo" | "bar">>;
+  type _BazNotPresent = Assert<Equal<"baz" extends keyof T ? true : false, false>>;
+  type _ExactShape = Assert<Equal<
+    T,
+    {
+      readonly foo: string;
+      readonly bar: number;
+    }
+  >>;
+}
+
+function fromArchetypeToTypeExcludesUnpickedComponents() {
+  const schema = Schema.FromArchetype(components, ["foo", "baz"]);
+  type T = Schema.ToType<typeof schema>;
+
+  type _BarNotPresent = Assert<Equal<"bar" extends keyof T ? true : false, false>>;
+  type _ExactShape = Assert<Equal<
+    T,
+    {
+      readonly foo: string;
+      readonly baz: boolean;
+    }
+  >>;
+}
+
+function fromComponentsToTypeMatchesExactComponentMap() {
+  const schema = Schema.FromComponents(
+    { foo: components.foo, bar: components.bar },
+    ["foo", "bar"],
+  );
+  type T = Schema.ToType<typeof schema>;
+
+  type _ExactKeys = Assert<Equal<keyof T, "foo" | "bar">>;
+  type _BazNotPresent = Assert<Equal<"baz" extends keyof T ? true : false, false>>;
+  type _ExactShape = Assert<Equal<
+    T,
+    {
+      readonly foo: string;
+      readonly bar: number;
+    }
+  >>;
+}
+
+function fromComponentsExtraPropertiesBecomeOptionalInToType() {
+  const schema = Schema.FromComponents(components, ["foo", "bar"]);
+  type T = Schema.ToType<typeof schema>;
+
+  type _BazIsOptional = Assert<Equal<
+    T,
+    {
+      readonly foo: string;
+      readonly bar: number;
+      readonly baz?: boolean;
+    }
+  >>;
+  type _BazKeyPresent = Assert<Equal<"baz" extends keyof T ? true : false, true>>;
+}
+
+function fromArchetypePreservesArchetypeOrder() {
+  const schema = Schema.FromArchetype(components, ["baz", "foo"]);
+
+  type _RequiredOrder = Assert<Equal<typeof schema.required, readonly ["baz", "foo"]>>;
+  type _PropertyKeys = Assert<
+    Equal<keyof typeof schema.properties, "foo" | "baz">
+  >;
+  type _BarNotInProperties = Assert<
+    Equal<"bar" extends keyof typeof schema.properties ? true : false, false>
+  >;
+}
+

--- a/packages/data/src/schema/public.ts
+++ b/packages/data/src/schema/public.ts
@@ -4,3 +4,5 @@ export * from "./schema.js";
 export * from "./to-vertex-buffer-layout.js";
 export * from "./nullable.js";
 export * from "./to-type.js";
+export * from "./from-components.js";
+export * from "./from-archetype.js";


### PR DESCRIPTION
## Summary
- Add `Schema.FromComponents` to build an object schema from a component property map and optional required key tuple.
- Add `Schema.FromArchetype` to pick components by archetype keys (via a typed `Pick`) and delegate to `FromComponents`, so `Schema.ToType` only includes archetype fields.
- Include unit tests and compile-time type tests, including negative checks that unpicked components are absent (not optional).

## Test plan
- [ ] `pnpm typecheck` in `packages/data`
- [ ] `pnpm test src/schema/from-components.test.ts`
- [ ] Hover/`ToType` on `Schema.FromArchetype(components, ["foo", "bar"])` yields only `foo` and `bar` (no optional extras)


Made with [Cursor](https://cursor.com)