### PR TITLE
fix(data): fromData resets nonPersistent space to defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.77",
+    "version": "0.9.78",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.77",
+    "version": "0.9.78",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.77",
+  "version": "0.9.78",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/store/core/create-core.ts
+++ b/packages/data/src/ecs/store/core/create-core.ts
@@ -259,6 +259,19 @@ export function createCore<NC extends ComponentSchemas>(newComponentSchemas: NC)
                 return;
             }
             Object.assign(componentSchemas, data.componentSchemas);
+            // The non-persistent (negative-ID) space is never captured by
+            // toData, so a load must revert it to defaults rather than leak the
+            // loading store's pre-load live values across the load. Clear it the
+            // same way reset() does; the persistent side below is fully
+            // overwritten by the restore, so only the nonPersistent rows need
+            // clearing here. The store layer re-seeds nonPersistent resource
+            // defaults afterward (its rowCount === 0 re-init guard).
+            nonPersistentLocationTable.reset();
+            for (const archetype of archetypes) {
+                if (archetype.components.has("nonPersistent")) {
+                    archetype.rowCount = 0;
+                }
+            }
             persistentLocationTable.fromData(data.entityLocationTableData);
             for (const { componentNames, data: archetypeData } of data.archetypesData) {
                 // Recreating the archetype reserves its id and leaves it

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -689,6 +689,60 @@ describe("createStore", () => {
             expect((newStore.resources as any).score).toBe(0);
         });
 
+        it("reverts a nonPersistent resource to its default when loading into a populated (non-fresh) store", () => {
+            const schema = {
+                components: {},
+                resources: {
+                    score: { default: 0 as number, nonPersistent: true },
+                    persistentScore: { default: 0 as number },
+                },
+                archetypes: {},
+            } as const;
+
+            // Save a snapshot from a source store.
+            const source = createStore(schema as any);
+            (source.resources as any).persistentScore = 123;
+            const snapshot = source.toData(true);
+
+            // Load into a store that ALREADY holds non-default state — the
+            // same-instance Save-As -> Load path. The nonPersistent resource
+            // is never captured by toData, so the only correct post-load value
+            // is its default. Leaving the pre-load live value in place would
+            // leak it across the load (the stale-blob-URL bug). This must match
+            // reset()'s treatment of the nonPersistent space.
+            const target = createStore(schema as any);
+            (target.resources as any).score = 999;
+            (target.resources as any).persistentScore = 456;
+            target.fromData(snapshot);
+
+            expect((target.resources as any).score).toBe(0);
+            expect((target.resources as any).persistentScore).toBe(123);
+        });
+
+        it("clears a nonPersistent entity present before the load when loading into a populated store", () => {
+            const selectionSchema = { type: "boolean", default: false } as const satisfies Schema;
+            const makeStore = () => createStore({
+                components: { selection: selectionSchema },
+                resources: {},
+                archetypes: {},
+            });
+
+            const source = makeStore();
+            const snapshot = source.toData(true);
+
+            // Target holds a nonPersistent entity (negative-ID space) before the
+            // load. fromData must clear it — the nonPersistent space is never
+            // serialized, so a load resets it exactly as reset() would.
+            const target = makeStore();
+            const selectionArchetype = target.ensureArchetype(["id", "selection", "nonPersistent"]);
+            const selectionEntity = selectionArchetype.insert({ selection: true, nonPersistent: true });
+            expect(target.read(selectionEntity)).not.toBeNull();
+
+            target.fromData(snapshot);
+
+            expect(target.read(selectionEntity)).toBeNull();
+        });
+
         it("preserves archetype ids across serialization when a nonPersistent archetype precedes a persistent one", () => {
             const selectionSchema = { type: "boolean", default: false } as const satisfies Schema;
             const positionScalarSchema = { type: "number", default: 0 } as const satisfies Schema;


### PR DESCRIPTION
## Description

`db.fromData()` restored only the persistent side of the store and left the negative-ID **nonPersistent** space (nonPersistent resources + entities) holding the *loading* store's pre-load live values. This is inconsistent with `db.reset()`, which reverts nonPersistent state to its schema defaults.

Because nonPersistent data is never captured by `toData()` (only its archetype `componentNames`, never `data`), the only correct value after a load is the **default**. Leaving the stale live value leaks it across a same-instance load — e.g. a Save-As → Load in the same session keeping every pre-load `blob:` URL forever (the downstream FFP "video clips not visible after reopen" thumbnail bug).

### Fix

`core.fromData` now resets the nonPersistent location table and zeroes nonPersistent archetype rows before restoring the persistent side (which is fully overwritten anyway). The store layer then re-seeds nonPersistent resource defaults via its existing `rowCount === 0` re-init guard. This mirrors `reset()` exactly.

### Why existing tests missed it

Every `fromData` test loaded a snapshot into a **freshly-constructed** store, whose nonPersistent resources were already at their defaults — so the assertions passed vacuously, not because `fromData` reset anything. Added red-green coverage that loads into a **populated (non-fresh)** store:

- a nonPersistent resource holding a non-default value reverts to default after load
- a nonPersistent entity present before the load is cleared

Version bumped to `0.9.78`.

## Testing

- `vitest run --project node` — 1343 tests pass; new populated-store cases are red without the fix, green with it.