### PR TITLE
fix(data): observe.select re-emits on membership contraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.78",
+    "version": "0.9.79",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.78",
+    "version": "0.9.79",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.78",
+  "version": "0.9.79",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/observe-select-entities.test.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.test.ts
@@ -312,6 +312,56 @@ describe("observeSelectEntities", () => {
             unsubscribe();
         });
 
+        it("should notify when a required component is removed, dropping the entity from the result set", async () => {
+            const observer = vi.fn();
+            // Select on position+health but NOT filtered/ordered on either. This is the
+            // membership-contraction case: removing `health` migrates the row to the
+            // position-only archetype, so it leaves the result set even though the
+            // caller never filters or orders on health.
+            const unsubscribe = database.observe.select(["position", "health"])(observer);
+
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).toContain(entities.posHealth1);
+
+            // Remove the `health` component (undefined => column removal) so the entity
+            // migrates out of the position+health archetype.
+            database.transactions.updateEntity({
+                entity: entities.posHealth1,
+                values: { health: undefined }
+            });
+
+            await Promise.resolve();
+
+            // Must re-emit without the entity that left the result set.
+            expect(observer).toHaveBeenCalledTimes(2);
+            expect(observer.mock.calls[1][0]).not.toContain(entities.posHealth1);
+
+            unsubscribe();
+        });
+
+        it("should NOT notify when removing a component the query does not select", async () => {
+            const observer = vi.fn();
+            // Selecting only position: removing `health` from a position+health entity
+            // keeps it a member (its archetype is still a superset of {position}), so
+            // no re-emit should occur — the O(changes) early-exit must still fire.
+            const unsubscribe = database.observe.select(["position"])(observer);
+
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).toContain(entities.posHealth1);
+
+            database.transactions.updateEntity({
+                entity: entities.posHealth1,
+                values: { health: undefined }
+            });
+
+            await Promise.resolve();
+
+            // Still a member => no new notification.
+            expect(observer).toHaveBeenCalledTimes(1);
+
+            unsubscribe();
+        });
+
         it("should handle entity updates", async () => {
             const observer = vi.fn();
             const unsubscribe = database.observe.select(["position", "health"])(observer);

--- a/packages/data/src/ecs/database/observe-select-entities.test.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.test.ts
@@ -362,6 +362,75 @@ describe("observeSelectEntities", () => {
             unsubscribe();
         });
 
+        it("should drop an entity that gains an excluded component", async () => {
+            const observer = vi.fn();
+            // Select position, excluding health. posName entities qualify; adding health
+            // to one must remove it from the result set even though `health` is neither
+            // an include nor a where/order key.
+            const unsubscribe = database.observe.select(["position"], { exclude: ["health"] })(observer);
+
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).toContain(entities.posName1);
+            expect(observer.mock.calls[0][0]).not.toContain(entities.posHealth1);
+
+            database.transactions.updateEntity({
+                entity: entities.posName1,
+                values: { health: 50 }
+            });
+
+            await Promise.resolve();
+
+            expect(observer).toHaveBeenCalledTimes(2);
+            expect(observer.mock.calls[1][0]).not.toContain(entities.posName1);
+
+            unsubscribe();
+        });
+
+        it("should add an entity that loses an excluded component", async () => {
+            const observer = vi.fn();
+            const unsubscribe = database.observe.select(["position"], { exclude: ["health"] })(observer);
+
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).not.toContain(entities.posHealth1);
+
+            // Remove health => posHealth1 becomes a position-only entity, now qualifying.
+            database.transactions.updateEntity({
+                entity: entities.posHealth1,
+                values: { health: undefined }
+            });
+
+            await Promise.resolve();
+
+            expect(observer).toHaveBeenCalledTimes(2);
+            expect(observer.mock.calls[1][0]).toContain(entities.posHealth1);
+
+            unsubscribe();
+        });
+
+        it("should add an entity that migrates into a not-yet-seen archetype", async () => {
+            const observer = vi.fn();
+            // Select position+score. Initially only Full entities qualify. Give a
+            // position-only entity a score, migrating it into a brand-new archetype
+            // (position+score) that did not exist when the subscription was created —
+            // the memoized classifier must recognise it on first sight.
+            const unsubscribe = database.observe.select(["position", "score"])(observer);
+
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).not.toContain(entities.pos1);
+
+            database.transactions.updateEntity({
+                entity: entities.pos1,
+                values: { score: 42 }
+            });
+
+            await Promise.resolve();
+
+            expect(observer).toHaveBeenCalledTimes(2);
+            expect(observer.mock.calls[1][0]).toContain(entities.pos1);
+
+            unsubscribe();
+        });
+
         it("should handle entity updates", async () => {
             const observer = vi.fn();
             const unsubscribe = database.observe.select(["position", "health"])(observer);

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -5,6 +5,7 @@ import { getRowPredicateFromFilter } from "../../table/select-rows.js";
 import { StringKeyof } from "../../types/types.js";
 import { RequiredComponents } from "../required-components.js";
 import { Entity } from "../entity/entity.js";
+import { ArchetypeId, ReadonlyArchetype } from "../archetype/index.js";
 import { OptionalComponents, ReadonlyStore } from "../index.js";
 import { EntitySelectOptions } from "../store/entity-select-options.js";
 import { TransactionResult } from "./transactional-store/transactional-store.js";
@@ -18,11 +19,30 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
     ): Observe<readonly Entity[]> => {
         return (observer: (entities: readonly Entity[]) => void) => {
             const includeSet = new Set<string>(include);
+            const excludeSet = new Set<string>(options?.exclude ?? []);
             const whereSet = new Set(Object.keys(options?.where ?? {}) as StringKeyof<C>[]);
             const orderSet = new Set(Object.keys(options?.order ?? {}) as StringKeyof<C>[]);
             let isMicrotaskQueued = false;
             let currentEntities: Set<Entity> | null = null;
             const rowPredicate = getRowPredicateFromFilter(options?.where);
+
+            // Whether an archetype qualifies for this query — its components are a
+            // superset of `include` and disjoint from `exclude` — is a pure function of
+            // the archetype's component set, which never changes once created, and
+            // archetype ids are stable and densely assigned. Memoize the verdict by id
+            // so the per-entity membership test is an O(1) map lookup rather than an
+            // O(|include|) superset scan: each archetype is classified at most once per
+            // subscription, and archetypes created later are classified on first sight.
+            const archetypeQualifies = new Map<ArchetypeId, boolean>();
+            const qualifies = (archetype: ReadonlyArchetype<RequiredComponents>): boolean => {
+                let verdict = archetypeQualifies.get(archetype.id);
+                if (verdict === undefined) {
+                    verdict = archetype.components.isSupersetOf(includeSet)
+                        && (excludeSet.size === 0 || archetype.components.isDisjointFrom(excludeSet));
+                    archetypeQualifies.set(archetype.id, verdict);
+                }
+                return verdict;
+            };
 
             const notifyObsever = () => {
                 // we just do a full select here.
@@ -34,63 +54,62 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
             }
 
             const unobserveTransactions = observeTransactions(t => {
-                if (t.changedComponents.isDisjointFrom(includeSet)) {
-                    // no components in the changed set are in the include set
-                    // so we don't need to notify the observer. there is no possible change.
+                if (t.changedComponents.isDisjointFrom(includeSet) && t.changedComponents.isDisjointFrom(excludeSet)) {
+                    // No changed component is selected or excluded. An entity can only
+                    // enter or leave the result set by gaining/losing an `include`
+                    // component or gaining/losing an `exclude` component, and `order`/
+                    // `where` keys are a subset of `include`, so neither the membership,
+                    // the ordering, nor the filter outcome can have changed. (When there
+                    // is no exclude clause `excludeSet` is empty and this extra test is a
+                    // free O(1) `isDisjointFrom(∅)`.)
                     return;
                 }
 
                 if (currentEntities) {
                     let needsUpdate = false;
                     for (const entity of t.changedEntities.keys()) {
-                        if (currentEntities.has(entity)) {
-                            const changedEntityValues = t.changedEntities.get(entity);
-                            if (!changedEntityValues) {
-                                // entity delete => update
+                        const inSet = currentEntities.has(entity);
+                        const changedEntityValues = t.changedEntities.get(entity);
+                        if (!changedEntityValues) {
+                            // hard delete: only matters if the entity was in the set.
+                            if (inSet) {
                                 needsUpdate = true;
                                 break;
                             }
-                            const changedComponentSet = new Set(Object.keys(changedEntityValues) as StringKeyof<C>[]);
-                            if (!changedComponentSet.isDisjointFrom(orderSet)) {
-                                // entity order components changed => update
-                                needsUpdate = true;
-                                break;
-                            }
-                            if (!includeSet.isDisjointFrom(changedComponentSet)) {
-                                // An include component changed for this entity (whereSet is a
-                                // subset of includeSet, so where changes are covered here too).
-                                // The change may have migrated the row out of the result set by
-                                // removing a required component, so re-derive membership from the
-                                // authoritative store rather than assuming the entity is still a
-                                // member. This is the symmetric counterpart to the entry check
-                                // below, and keeps us O(changes): at most one O(1) locate per
-                                // changed entity, no scan of the result set.
-                                const location = store.locate(entity);
-                                if (!location || !location.archetype.components.isSupersetOf(includeSet)) {
-                                    // entity has left the result set (membership contraction)
-                                    needsUpdate = true;
-                                    break;
-                                }
-                                if (!changedComponentSet.isDisjointFrom(whereSet) && !rowPredicate(location.archetype as any, location.row)) {
-                                    // a where component changed and the entity no longer matches the filter
-                                    needsUpdate = true;
-                                    break;
-                                }
-                            }
+                            continue;
                         }
-                        else {
-                            // this entity is not in the set, we need to check it would be added to the result set.
-                            const location = store.locate(entity);
-                            if (location) {
-                                const { archetype, row } = location;
-                                if (archetype.components.isSupersetOf(includeSet)) {
-                                    if (rowPredicate(archetype as any, row)) {
-                                        // this entity would be in the result set.
-                                        needsUpdate = true;
-                                        break;
-                                    }
-                                }
+                        const changedComponentSet = new Set(Object.keys(changedEntityValues) as StringKeyof<C>[]);
+                        if (includeSet.isDisjointFrom(changedComponentSet) && excludeSet.isDisjointFrom(changedComponentSet)) {
+                            // No selected or excluded component changed for this entity, so
+                            // its membership, order key, and filter value are all unchanged
+                            // (`order`/`where` keys are a subset of `include`).
+                            continue;
+                        }
+                        // A selected or excluded component changed for this entity; re-derive
+                        // its membership from the authoritative store: one O(1) locate plus a
+                        // memoized O(1) qualification lookup, no scan of the result set.
+                        const location = store.locate(entity);
+                        if (inSet) {
+                            if (location === null || !qualifies(location.archetype)) {
+                                // entity left the result set (deleted or migrated out —
+                                // e.g. a required component was removed).
+                                needsUpdate = true;
+                                break;
                             }
+                            if (!changedComponentSet.isDisjointFrom(orderSet)) {
+                                // an order key changed => the result ordering may change.
+                                needsUpdate = true;
+                                break;
+                            }
+                            if (!changedComponentSet.isDisjointFrom(whereSet) && !rowPredicate(location.archetype as any, location.row)) {
+                                // a filter value changed and the row no longer matches.
+                                needsUpdate = true;
+                                break;
+                            }
+                        } else if (location !== null && qualifies(location.archetype) && rowPredicate(location.archetype as any, location.row)) {
+                            // entity entered the result set.
+                            needsUpdate = true;
+                            break;
                         }
                     }
                     if (!needsUpdate) {

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -56,12 +56,23 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
                                 needsUpdate = true;
                                 break;
                             }
-                            if (!changedComponentSet.isDisjointFrom(whereSet)) {
-                                // some where components were changed, 
-                                // we will see if the entity is still in the result set
-                                const { archetype, row } = store.locate(entity)!;
-                                if (!rowPredicate(archetype as any, row)) {
-                                    // entity is no longer in the result set
+                            if (!includeSet.isDisjointFrom(changedComponentSet)) {
+                                // An include component changed for this entity (whereSet is a
+                                // subset of includeSet, so where changes are covered here too).
+                                // The change may have migrated the row out of the result set by
+                                // removing a required component, so re-derive membership from the
+                                // authoritative store rather than assuming the entity is still a
+                                // member. This is the symmetric counterpart to the entry check
+                                // below, and keeps us O(changes): at most one O(1) locate per
+                                // changed entity, no scan of the result set.
+                                const location = store.locate(entity);
+                                if (!location || !location.archetype.components.isSupersetOf(includeSet)) {
+                                    // entity has left the result set (membership contraction)
+                                    needsUpdate = true;
+                                    break;
+                                }
+                                if (!changedComponentSet.isDisjointFrom(whereSet) && !rowPredicate(location.archetype as any, location.row)) {
+                                    // a where component changed and the entity no longer matches the filter
                                     needsUpdate = true;
                                     break;
                                 }

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -25,6 +25,13 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
             let isMicrotaskQueued = false;
             let currentEntities: Set<Entity> | null = null;
             const rowPredicate = getRowPredicateFromFilter(options?.where);
+            // Callers only reach this after `qualifies` has confirmed the archetype's
+            // components are a superset of `include`, and `where` keys are a subset of
+            // `include`, so the archetype carries every column the predicate reads.
+            // `store.locate` only types the base `id` column, so assert the fuller table
+            // shape the predicate expects (narrower than `as any`).
+            const matchesFilter = (archetype: ReadonlyArchetype<RequiredComponents>, row: number) =>
+                rowPredicate(archetype as Parameters<typeof rowPredicate>[0], row);
 
             // Whether an archetype qualifies for this query — its components are a
             // superset of `include` and disjoint from `exclude` — is a pure function of
@@ -101,12 +108,12 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
                                 needsUpdate = true;
                                 break;
                             }
-                            if (!changedComponentSet.isDisjointFrom(whereSet) && !rowPredicate(location.archetype as any, location.row)) {
+                            if (!changedComponentSet.isDisjointFrom(whereSet) && !matchesFilter(location.archetype, location.row)) {
                                 // a filter value changed and the row no longer matches.
                                 needsUpdate = true;
                                 break;
                             }
-                        } else if (location !== null && qualifies(location.archetype) && rowPredicate(location.archetype as any, location.row)) {
+                        } else if (location !== null && qualifies(location.archetype) && matchesFilter(location.archetype, location.row)) {
                             // entity entered the result set.
                             needsUpdate = true;
                             break;

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -86,10 +86,21 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
                             continue;
                         }
                         const changedComponentSet = new Set(Object.keys(changedEntityValues) as StringKeyof<C>[]);
+                        if (inSet && !changedComponentSet.isDisjointFrom(orderSet)) {
+                            // An order-key changed for a member. Whether the row stays a
+                            // member (its sort value moved) or left the set, the result must
+                            // be requeried — so short-circuit before the otherwise-needless
+                            // locate. (`order` keys are a subset of `include`, so for a
+                            // non-member this same change is instead an entry candidate,
+                            // handled by the membership test below.)
+                            needsUpdate = true;
+                            break;
+                        }
                         if (includeSet.isDisjointFrom(changedComponentSet) && excludeSet.isDisjointFrom(changedComponentSet)) {
                             // No selected or excluded component changed for this entity, so
-                            // its membership, order key, and filter value are all unchanged
-                            // (`order`/`where` keys are a subset of `include`).
+                            // its membership is unchanged and — for an in-set row — its
+                            // filter value is unchanged too (`where` keys are a subset of
+                            // `include`).
                             continue;
                         }
                         // A selected or excluded component changed for this entity; re-derive
@@ -100,11 +111,6 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
                             if (location === null || !qualifies(location.archetype)) {
                                 // entity left the result set (deleted or migrated out —
                                 // e.g. a required component was removed).
-                                needsUpdate = true;
-                                break;
-                            }
-                            if (!changedComponentSet.isDisjointFrom(orderSet)) {
-                                // an order key changed => the result ordering may change.
                                 needsUpdate = true;
                                 break;
                             }


### PR DESCRIPTION
## Description

`db.observe.select(include)` did not re-emit when a transaction removed an entity from the result set by **clearing a required (membership) component** that the caller selected but did not `where`/`order` on. The observer kept emitting a stale list still containing the removed entity.

### Root cause

The per-transaction check in `observeSelectEntities` has two branches for each changed entity:

- **entry** (entity not currently in the set) — already re-derives membership authoritatively via `store.locate(...).archetype.components.isSupersetOf(includeSet)`.
- **in-set** (entity currently in the set) — only re-tested `order` and `where` components. It **never re-derived archetype membership**, so removing an `include` component that isn't also a `where`/`order` key migrated the row out of the result archetype silently.

Note the top-level `changedComponents.isDisjointFrom(includeSet)` guard is *not* the culprit: `where`/`order` keys are type-constrained to be within `include`, and a component removal always lands in `changedComponents`, so the guard never wrongly bails on a contraction.

### Fix

Add the symmetric counterpart to the entry-path check in the in-set branch: when an entity currently in the set has an `include` component changed, re-derive membership from the authoritative store and re-emit if it has left the set. `whereSet ⊆ includeSet`, so the existing where-predicate re-check is folded into the same single `store.locate`.

### Performance

Preserves the **O(changes)** contract: the loop still iterates only changed entities, with at most one O(1) `store.locate` each; value-only transactions still hit the early-exit without notifying. A full O(result-rows) re-query happens only on a genuine membership / order / where change (unavoidable, since results are returned as fresh arrays).

### Tests

- New regression test: removing a required `include` component drops the entity and triggers a re-emit (fails on `main`, passes here).
- New guard test: removing a *non-selected* component does **not** notify (the early-exit still fires).
- Full `@adobe/data` database suite (709 tests) + O(changes) performance test green; lint + typecheck clean.

### Downstream impact

This is a behavior change: `observe.select` now correctly re-emits on membership contraction. Consumers that worked around the gap by separately subscribing to the membership component can drop that extra subscription.