### PR TITLE
feat(data): add Observe.fromKeys reactive keyed-collection combinator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "private": true,
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Todo sample app demonstrating @adobe/data with Lit",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.79",
+    "version": "0.9.80",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.79",
+    "version": "0.9.80",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/observe/from-keys.test.ts
+++ b/packages/data/src/observe/from-keys.test.ts
@@ -1,0 +1,165 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { describe, test, expect, vi } from "vitest";
+import { Notify, Observe } from "./index.js";
+import { fromKeys } from "./from-keys.js";
+
+/**
+ * A manually-driven observe function: emits its current value synchronously on
+ * subscribe once seeded, re-emits on `emit`, and tracks live subscriber count so
+ * tests can assert per-key value subscription reuse / disposal.
+ */
+function manual<T>(initial?: { value: T }) {
+    const observers = new Set<Notify<T>>();
+    let seeded = initial !== undefined;
+    let current = initial?.value as T;
+    const observe: Observe<T> = (notify) => {
+        observers.add(notify);
+        if (seeded) {
+            notify(current);
+        }
+        return () => {
+            observers.delete(notify);
+        };
+    };
+    return {
+        observe,
+        emit(value: T) {
+            seeded = true;
+            current = value;
+            for (const notify of [...observers]) {
+                notify(value);
+            }
+        },
+        subscriberCount: () => observers.size,
+    };
+}
+
+describe("fromKeys", () => {
+    test("emits per-key values in key order, synchronously when the values are synchronous", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b", "c"] });
+        const values: Record<string, ReturnType<typeof manual<number>>> = {
+            a: manual({ value: 1 }),
+            b: manual({ value: 2 }),
+            c: manual({ value: 3 }),
+        };
+        const results: (readonly number[])[] = [];
+        const unsubscribe = fromKeys(keys.observe, (k: string) => values[k].observe)((v) => results.push(v));
+
+        expect(results).toEqual([[1, 2, 3]]);
+        unsubscribe();
+    });
+
+    test("re-emits only the changed key's slot; the other keys keep their value and are not re-subscribed", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b"] });
+        const a = manual({ value: 1 });
+        const b = manual({ value: 2 });
+        const observeValue = vi.fn((k: string) => (k === "a" ? a.observe : b.observe));
+
+        const results: (readonly number[])[] = [];
+        const unsubscribe = fromKeys(keys.observe, observeValue)((v) => results.push(v));
+
+        expect(results).toEqual([[1, 2]]);
+        // one value subscription per key, created once
+        expect(observeValue).toHaveBeenCalledTimes(2);
+        expect(a.subscriberCount()).toBe(1);
+        expect(b.subscriberCount()).toBe(1);
+
+        a.emit(10);
+        expect(results).toEqual([[1, 2], [10, 2]]);
+        // b was untouched: no extra observeValue call, still one subscription
+        expect(observeValue).toHaveBeenCalledTimes(2);
+        expect(b.subscriberCount()).toBe(1);
+
+        unsubscribe();
+    });
+
+    test("adding a key subscribes a new value and re-emits with it appended", () => {
+        const keys = manual<readonly string[]>({ value: ["a"] });
+        const a = manual({ value: 1 });
+        const b = manual({ value: 2 });
+        const map: Record<string, Observe<number>> = { a: a.observe, b: b.observe };
+
+        const results: (readonly number[])[] = [];
+        fromKeys(keys.observe, (k: string) => map[k])((v) => results.push(v));
+
+        expect(results).toEqual([[1]]);
+        keys.emit(["a", "b"]);
+        expect(results[results.length - 1]).toEqual([1, 2]);
+        expect(b.subscriberCount()).toBe(1);
+    });
+
+    test("removing a key unsubscribes its value and re-emits without it", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b"] });
+        const a = manual({ value: 1 });
+        const b = manual({ value: 2 });
+        const map: Record<string, Observe<number>> = { a: a.observe, b: b.observe };
+
+        const results: (readonly number[])[] = [];
+        fromKeys(keys.observe, (k: string) => map[k])((v) => results.push(v));
+
+        expect(b.subscriberCount()).toBe(1);
+        keys.emit(["a"]);
+        expect(results[results.length - 1]).toEqual([1]);
+        // b's value subscription was disposed
+        expect(b.subscriberCount()).toBe(0);
+        // a survived — still one subscription
+        expect(a.subscriberCount()).toBe(1);
+    });
+
+    test("reordering the keys re-emits the values in the new order without re-subscribing", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b"] });
+        const a = manual({ value: 1 });
+        const b = manual({ value: 2 });
+        const map: Record<string, Observe<number>> = { a: a.observe, b: b.observe };
+        const observeValue = vi.fn((k: string) => map[k]);
+
+        const results: (readonly number[])[] = [];
+        fromKeys(keys.observe, observeValue)((v) => results.push(v));
+
+        expect(results[results.length - 1]).toEqual([1, 2]);
+        keys.emit(["b", "a"]);
+        expect(results[results.length - 1]).toEqual([2, 1]);
+        // no new subscriptions for a reorder
+        expect(observeValue).toHaveBeenCalledTimes(2);
+    });
+
+    test("waits for every key to yield a value before the first emission", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b"] });
+        const a = manual({ value: 1 });
+        const b = manual<number>(); // not seeded — never yields synchronously
+        const map: Record<string, Observe<number>> = { a: a.observe, b: b.observe };
+
+        const results: (readonly number[])[] = [];
+        fromKeys(keys.observe, (k: string) => map[k])((v) => results.push(v));
+
+        // b has not produced a value, so nothing is emitted yet
+        expect(results).toEqual([]);
+        b.emit(2);
+        expect(results).toEqual([[1, 2]]);
+    });
+
+    test("emits an empty array for an empty key list", () => {
+        const keys = manual<readonly string[]>({ value: [] });
+        const results: (readonly number[])[] = [];
+        fromKeys(keys.observe, () => manual({ value: 0 }).observe)((v) => results.push(v));
+        expect(results).toEqual([[]]);
+    });
+
+    test("disposing unsubscribes the key list and every value", () => {
+        const keys = manual<readonly string[]>({ value: ["a", "b"] });
+        const a = manual({ value: 1 });
+        const b = manual({ value: 2 });
+        const map: Record<string, Observe<number>> = { a: a.observe, b: b.observe };
+
+        const unsubscribe = fromKeys(keys.observe, (k: string) => map[k])(() => {});
+        expect(keys.subscriberCount()).toBe(1);
+        expect(a.subscriberCount()).toBe(1);
+        expect(b.subscriberCount()).toBe(1);
+
+        unsubscribe();
+        expect(keys.subscriberCount()).toBe(0);
+        expect(a.subscriberCount()).toBe(0);
+        expect(b.subscriberCount()).toBe(0);
+    });
+});

--- a/packages/data/src/observe/from-keys.ts
+++ b/packages/data/src/observe/from-keys.ts
@@ -1,0 +1,89 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Observe } from "./index.js";
+
+/**
+ * Reactive keyed collection. Given an observable list of keys and a function
+ * that maps each key to an observe function for that key's value, yields an
+ * observe function of the per-key values in key order.
+ *
+ * Per-key value subscriptions are keyed by `===` identity and REUSED across
+ * list changes: when the key list changes, only added keys subscribe a value
+ * and only removed keys unsubscribe one — keys that remain are untouched. So a
+ * change in one key's value re-emits only that key's slot (every other key
+ * keeps its current value), without re-running or re-subscribing the rest.
+ *
+ * A result is only produced once every current key has yielded a value; if every
+ * value observe function yields synchronously on subscribe, the first result is
+ * produced synchronously. Re-emits whenever the key list changes or any live
+ * value yields.
+ *
+ * This is the dynamic, keyed counterpart to {@link fromArray} / {@link
+ * fromProperties} (which combine a fixed set of observe functions): here the set
+ * of value observe functions is itself driven by an observe function of keys.
+ *
+ * @param keys an observe function of the current key list (duplicate keys collapse)
+ * @param observeValue maps a key to the observe function for that key's value
+ */
+export function fromKeys<K, V>(
+  keys: Observe<readonly K[]>,
+  observeValue: (key: K) => Observe<V>
+): Observe<readonly V[]> {
+  return (notify) => {
+    const entries = new Map<K, { unsubscribe: () => void; value: V; ready: boolean }>();
+    let currentKeys: readonly K[] = [];
+    let keysReady = false;
+
+    const emitIfReady = () => {
+      if (!keysReady) {
+        return;
+      }
+      const values: V[] = [];
+      for (const key of currentKeys) {
+        const entry = entries.get(key);
+        // A newly-added key has not yielded its first value yet — wait for it.
+        if (entry === undefined || !entry.ready) {
+          return;
+        }
+        values.push(entry.value);
+      }
+      notify(values);
+    };
+
+    const ensureEntry = (key: K) => {
+      if (entries.has(key)) {
+        return;
+      }
+      const entry = { unsubscribe: () => {}, value: undefined as unknown as V, ready: false };
+      entries.set(key, entry);
+      entry.unsubscribe = observeValue(key)((value) => {
+        entry.value = value;
+        entry.ready = true;
+        emitIfReady();
+      });
+    };
+
+    const unsubscribeKeys = keys((nextKeys) => {
+      currentKeys = nextKeys;
+      const keep = new Set(nextKeys);
+      for (const [key, entry] of entries) {
+        if (!keep.has(key)) {
+          entry.unsubscribe();
+          entries.delete(key);
+        }
+      }
+      for (const key of nextKeys) {
+        ensureEntry(key);
+      }
+      keysReady = true;
+      emitIfReady();
+    });
+
+    return () => {
+      unsubscribeKeys();
+      for (const entry of entries.values()) {
+        entry.unsubscribe();
+      }
+      entries.clear();
+    };
+  };
+}

--- a/packages/data/src/observe/public.ts
+++ b/packages/data/src/observe/public.ts
@@ -9,6 +9,7 @@ export * from "./from-element-id.js";
 export * from "./from-element-properties-and-events.js";
 export * from "./from-element-property.js";
 export * from "./from-array.js";
+export * from "./from-keys.js";
 export * from "./from-properties.js";
 export * from "./from-promise-with-error.js";
 export * from "./from-promise.js";


### PR DESCRIPTION
## Description

Adds `Observe.fromKeys` — a reactive **keyed collection** combinator:

```ts
fromKeys<K, V>(keys: Observe<readonly K[]>, observeChild: (key: K) => Observe<V>): Observe<readonly V[]>
```

Given an observable list of keys and a factory mapping each key to a child observe function, it yields the child values in key order. Child subscriptions are keyed by `===` identity and **reused across list changes** — only added keys create a child and only removed keys dispose one — so a value change on one child re-emits *only that child's slot* (siblings keep their values, no recompute, no re-subscribe). It emits once every current child has yielded a value (synchronously when all children are synchronous), and re-emits on any key-list change or child emission.

This is the **dynamic, keyed counterpart** to the existing `fromArray` / `fromProperties`, which combine a *fixed* set of observe functions; here the set of children is itself driven by an observe function of keys.

### Motivation

It generalizes a local `fromEntities` helper written for `firefly-platform`'s `avTimelinePayload` reactive-graph refactor (select the ordered entity set → one per-entity child observable → collect), so that consumer can drop the private helper and import this instead. It is the "membership set → per-entity leaf" substrate for building O(changes) reactive dependency graphs over an ECS.

### Tests

New `from-keys.test.ts` (peer to the source): ordered emission, per-slot re-emit with sibling reuse (asserts sibling subscription count is untouched), key add / remove (disposes child) / reorder, waiting for all children before first emit, empty-list, and full disposal (keys + every child unsubscribed).

`pnpm run typecheck`, `pnpm run lint`, and the full `observe` suite (176 tests) pass. Version bumped to 0.9.80 via `pnpm run bump`.