### PR TITLE
data-ai: installer delivers rules too, focused README, skill-ref fix

### DIFF
--- a/packages/data-ai/README.md
+++ b/packages/data-ai/README.md
@@ -1,102 +1,60 @@
 # @adobe/data-ai
 
-Cross-agent architecture skills for [`@adobe/data`](https://www.npmjs.com/package/@adobe/data). One skill bundle, authored once, distributed two ways.
+AI architecture skills + rules for building applications with
+[`@adobe/data`](https://www.npmjs.com/package/@adobe/data) — a layered,
+spec-first feature structure (`data → ecs → ui`) kept honest by conformance
+tests. Versioned in lockstep with the library: `@adobe/data-ai@x.y.z` targets
+`@adobe/data@x.y.z`.
 
-Skills version in lockstep with the library: `@adobe/data-ai@x.y.z` describes `@adobe/data@x.y.z`.
+It installs two things:
 
-There are two distribution paths, one per agent family — they do **not** overlap:
+- **skills** — `build-*` commands that scaffold features and applications.
+- **rules** — the path-scoped conventions those skills follow while building.
 
-- **Claude Code → marketplace plugin** (see below). The installer never writes into `.claude/skills/`, so it can't collide with your own Claude skills.
-- **Cursor / Codex / other `.agents`-standard agents → `npx … install`** (below).
+> **For the installing agent:** find the block below that matches your host
+> (Claude Code or Cursor/other), run its commands, and stop. Each install owns a
+> namespaced folder and is a clean wipe-and-recopy, so re-running is also how you
+> **update** — it never touches files you authored.
 
-## Install (Cursor, Codex, `.agents` agents)
+## Install — Claude Code
 
-The installer copies the skill folders into a single namespaced bundle directory that agents which recurse `.agents/skills/` discover:
-
-```sh
-npx @adobe/data-ai@latest install
-```
-
-This writes `.agents/skills/adobe-data-ai/<name>/SKILL.md` for each skill. The whole `adobe-data-ai/` directory belongs to this package, so a re-run is a clean wipe-and-recopy that never touches skills you authored elsewhere. Commit the result to share it with your team.
-
-Options:
-
-```sh
-npx @adobe/data-ai@latest install --global      # into ~/.agents/skills/adobe-data-ai/
-npx @adobe/data-ai@latest install --dir=./sub    # into a specific base dir
-npx @adobe/data-ai@latest list                   # show bundled skills
-```
-
-## Install (Claude Code plugin)
-
-Claude Code does not scan `.agents/`; it consumes the skills as a native plugin from the `adobe/data` marketplace — no npm needed.
-
-Interactive:
+Skills load as a marketplace plugin; rules install into the project.
 
 ```
 /plugin marketplace add adobe/data
 /plugin install adobe-data-ai@adobe-data-skills
+npx @adobe/data-ai@latest install
 ```
 
-Or declaratively, so collaborators are prompted to auto-install on next launch — commit to your repo's `.claude/settings.json`:
+- Skills → the `adobe-data-ai` plugin. **Update:** `/plugin` → update `adobe-data-ai`.
+- Rules → `.claude/rules/adobe-data-ai/`. **Update:** re-run `npx @adobe/data-ai@latest install`.
 
-```json
-{
-  "extraKnownMarketplaces": {
-    "adobe-data-skills": {
-      "source": { "source": "github", "repo": "adobe/data" }
-    }
-  },
-  "enabledPlugins": {
-    "adobe-data-ai@adobe-data-skills": true
-  }
-}
+## Install — Cursor (and Codex / other `.agents` agents)
+
+One command installs both:
+
+```
+npx @adobe/data-ai@latest install
 ```
 
-The plugin cache is version-hashed and garbage-collected, so it is not a stable path to symlink against — prefer the `npx … install` copy model when you need a durable, cross-agent artifact.
+- Skills → `.agents/skills/adobe-data-ai/`.
+- Rules → `.claude/rules/adobe-data-ai/`.
+- **Update:** re-run the same command.
 
----
+## Use
 
-# Pragmatic Programming
+Ask your agent to run a build command — skills are available by name:
 
-## Target Audience
+- **`build-application`** — build a whole app: a base feature that hosts
+  lazily-loaded peer features.
+- **`build-feature`** — build one feature end to end. Pipes the per-layer skills
+  (`data → core-database → transactions → … → ui`), then conformance-tests the
+  result against its pure `data/` spec.
 
-Software engineers who want to build high quality applications with a sustainable velocity.
-
-## Goals
-
-The goal of effective software engineers is to generate a high rate of value per unit time.
-
-    rate = value / time
-
-We can improve the rate by either increasing value or decreasing time.
-
-- Quality: Write better applications. ▲value
-- Velocity: Write applications faster. ▼time
-
-### Code Priorities
-
-1. Correct: Does the job. This one is non-negotiable.
-2. Clear: Easily understood by both humans and AI.
-3. Changeable: Quickly and safely modified or extended.
-
-There is occasionally some tension between clarity and changeability. More abstraction or generic parameters may make things more changeable at the cost of some clarity.
-
-### Code Challenges
-
-- Complexity: Undermines every single one of our code priorities.
-
-Complexity is the limiting factor which defines the upper limit on how sophisticated of an application we are able to create and maintain at a practical velocity.
-
-The difficulty of dealing with complexity tends to increase at a greater than linear rate, especially once the short term context window of a human or ai agent is exceeded.
-
-### General Principles
-
-- Separation of Concerns: If two concerns can be separated then do it.
-- Avoid mutation: Immutable values are easier to reason about.
-- Use Small files: Aim for less than 200 loc. Decompose if > 500 loc.
-- Single concern per file: Export only a single declaration per file.
-- Avoid object oriented classes: Combines data concerns with functions.
-- Distinguish services from data: Services do things, data stores things.
-- Use static typing: Finds errors earlier and guides both AI and humans.
-- Avoid side effects: Pure functions are easier to comprehend and test.
+Both compose finer-grained skills that are installed alongside and discoverable
+by name when you want a single phase or a specialized flow: `build-data`,
+`build-core-database`, `build-indexes`, `build-transactions`, `build-computed`,
+`build-services`, `build-service-database`, `build-actions`, `build-systems`,
+`build-ui`, `build-app-entry`; plus `build-game`, `meta-build` (phase-by-phase
+in subagents), `review` (audit output against the rules), and `structure`
+(reason about layout).

--- a/packages/data-ai/bin/cli.mjs
+++ b/packages/data-ai/bin/cli.mjs
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
-// Installer for the @adobe/data-ai skill bundle (Cursor / Codex / .agents-standard agents).
+// Installer for the @adobe/data-ai bundle (Cursor / Codex / .agents-standard agents).
 //
-// Copies the SKILL.md folders shipped in this package into a single namespaced
-// bundle directory that agents which recurse `.agents/skills/` will discover:
+// Lays down two managed, namespaced directories the agent discovers:
 //
-//   .agents/skills/adobe-data-ai/<name>/SKILL.md
+//   .agents/skills/adobe-data-ai/<name>/SKILL.md   — the build-* skills
+//   .claude/rules/adobe-data-ai/**/*.md            — the architecture rules
 //
-// We own the `adobe-data-ai/` directory outright, so a refresh is a clean
-// wipe-and-recopy — it never touches skills you authored elsewhere.
+// We own both `adobe-data-ai/` directories outright, so a refresh is a clean
+// wipe-and-recopy — it never touches files you authored elsewhere. Re-running
+// the installer is therefore also how you update.
 //
-// Claude Code is intentionally NOT a target: it does not scan `.agents/`, and
-// copying into `.claude/skills/` could collide with a user's own skills.
-// Claude consumes these as the `adobe-data-ai` marketplace plugin instead
-// (see README).
+// Claude Code is intentionally NOT a skills target: it does not scan `.agents/`,
+// and copying into `.claude/skills/` could collide with a user's own skills — it
+// consumes the skills as the `adobe-data-ai` marketplace plugin instead. The
+// rules, however, install into `.claude/rules/adobe-data-ai/` for every agent
+// (Claude auto-injects them by their `paths:` globs; other agents read them by
+// name as their skills run). See README.
 
 import {
     cpSync,
@@ -30,25 +33,38 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, "..");
 const skillsSrc = join(pkgRoot, "skills");
+const rulesSrc = join(pkgRoot, ".claude", "rules");
 const pkg = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
 const { name: PKG_NAME, version: VERSION } = pkg;
 
-// Namespaced bundle folder — the whole directory belongs to this package.
+// Namespaced bundle folder — the whole directory belongs to this package, under
+// each agent root.
 const BUNDLE = "adobe-data-ai";
 
-// Written into the bundle root on every install. Claude Code loads nested
-// CLAUDE.md files when working in a subtree, so an agent that opens a skill
-// here sees the do-not-edit notice before touching it.
-const CLAUDE_MD = `# Externally managed — do not edit
+// A do-not-edit notice dropped at each bundle root. Claude Code loads nested
+// CLAUDE.md files when working in a subtree, so an agent that opens one of these
+// folders sees the notice before touching anything. `extra` adds a pointer to
+// the companion bundle.
+function notice(extra) {
+    return `# Externally managed — do not edit
 
-The skills in this folder are installed and managed by the \`@adobe/data-ai\`
+The files in this folder are installed and managed by the \`${PKG_NAME}\`
 package. This entire directory is **deleted and rebuilt** on every
-\`npx @adobe/data-ai install\`, so any local edit here is silently discarded
-on the next reinstall or version upgrade.
+\`npx ${PKG_NAME} install\`, so any local edit here is silently discarded on the
+next reinstall or version upgrade.
 
-To change a skill, edit it upstream in the \`@adobe/data-ai\` package and
-publish a new version, then reinstall — do not modify these files in place.
-`;
+To change them, edit upstream in the \`${PKG_NAME}\` package and publish a new
+version, then reinstall — do not modify these files in place.
+${extra ? `\n${extra}\n` : ""}`;
+}
+
+function writeMeta(bundleDir, noticeBody, extraMeta) {
+    writeFileSync(join(bundleDir, "CLAUDE.md"), noticeBody);
+    writeFileSync(
+        join(bundleDir, ".data-ai.json"),
+        JSON.stringify({ package: PKG_NAME, version: VERSION, ...extraMeta }, null, 2) + "\n",
+    );
+}
 
 function discoverSkills() {
     if (!existsSync(skillsSrc)) return [];
@@ -58,18 +74,41 @@ function discoverSkills() {
         .sort();
 }
 
-function installTo(bundleDir, skills) {
-    // We own this directory — wipe and recopy for a clean refresh.
+// Recursively count the rule `.md` files, excluding the top-level README.md
+// (rules-authoring meta doc, not a rule — and it carries no `paths:` guard).
+function countRules(dir) {
+    let n = 0;
+    for (const d of readdirSync(dir, { withFileTypes: true })) {
+        if (d.isDirectory()) n += countRules(join(dir, d.name));
+        else if (d.name.endsWith(".md") && !(dir === rulesSrc && d.name === "README.md")) n += 1;
+    }
+    return n;
+}
+
+function installSkills(base, skills) {
+    const bundleDir = join(base, ".agents", "skills", BUNDLE);
     rmSync(bundleDir, { recursive: true, force: true });
     mkdirSync(bundleDir, { recursive: true });
     for (const name of skills) {
         cpSync(join(skillsSrc, name), join(bundleDir, name), { recursive: true });
     }
-    writeFileSync(join(bundleDir, "CLAUDE.md"), CLAUDE_MD);
-    writeFileSync(
-        join(bundleDir, ".data-ai.json"),
-        JSON.stringify({ package: PKG_NAME, version: VERSION, skills }, null, 2) + "\n",
+    writeMeta(
+        bundleDir,
+        notice("The architecture rules these skills follow are installed at\n`.claude/rules/adobe-data-ai/` (referenced by name from each SKILL.md)."),
+        { skills },
     );
+    return bundleDir;
+}
+
+function installRules(base) {
+    const bundleDir = join(base, ".claude", "rules", BUNDLE);
+    rmSync(bundleDir, { recursive: true, force: true });
+    mkdirSync(bundleDir, { recursive: true });
+    // Copy the whole rules tree, minus the top-level README.md meta doc.
+    const readme = join(rulesSrc, "README.md");
+    cpSync(rulesSrc, bundleDir, { recursive: true, filter: (src) => src !== readme });
+    writeMeta(bundleDir, notice(), { rules: countRules(rulesSrc) });
+    return bundleDir;
 }
 
 function parseArgs(argv) {
@@ -87,19 +126,20 @@ function parseArgs(argv) {
 
 const HELP = `${PKG_NAME} v${VERSION}
 
-Install the architecture-skill bundle for Cursor, Codex, and other agents
-that scan .agents/skills/. (Claude Code uses the marketplace plugin instead.)
+Install the architecture skills + rules for Cursor, Codex, and other agents.
+(Claude Code gets the skills from the marketplace plugin; the rules install the
+same way for every agent — see README.)
 
 Usage:
   npx ${PKG_NAME}@latest install [options]
   npx ${PKG_NAME}@latest list
 
 Commands:
-  install   Copy skills into .agents/skills/${BUNDLE}/ (default).
+  install   Skills → .agents/skills/${BUNDLE}/, rules → .claude/rules/${BUNDLE}/ (default).
   list      Print the skills bundled in this package.
 
 Options:
-  --global, -g    Install into your home directory (~/.agents/skills/${BUNDLE}/)
+  --global, -g    Install into your home directory (~/.agents, ~/.claude)
                   instead of the current project.
   --dir=<path>    Base directory to install into (default: cwd).
   --help, -h      Show this help.
@@ -134,13 +174,13 @@ function main() {
     }
 
     const base = flags.has("global") ? homedir() : dir ? resolve(dir) : process.cwd();
-    const bundleDir = join(base, ".agents", "skills", BUNDLE);
+    const skillsDir = installSkills(base, skills);
+    const rulesDir = installRules(base);
+    const ruleCount = countRules(rulesSrc);
 
-    installTo(bundleDir, skills);
-
-    process.stdout.write(`Installed ${skills.length} skill(s) from ${PKG_NAME} v${VERSION}\n`);
-    process.stdout.write(`  ${bundleDir}\n`);
-    process.stdout.write(`Skills: ${skills.join(", ")}\n`);
+    process.stdout.write(`Installed ${PKG_NAME} v${VERSION}\n`);
+    process.stdout.write(`  ${skills.length} skills → ${skillsDir}\n`);
+    process.stdout.write(`  ${ruleCount} rules  → ${rulesDir}\n`);
 }
 
 main();

--- a/packages/data-ai/skills/build-data/SKILL.md
+++ b/packages/data-ai/skills/build-data/SKILL.md
@@ -14,5 +14,5 @@ and other `data/` declarations):
 The schema is the single source of truth; the type derives from it (`Schema.ToType`).
 Helpers are pure and unit-tested. Run this first — every other layer imports `data/`.
 
-The how is in the auto-loading rules: `features/data/index.md`, `data/state.md`, and
+The how is in the auto-loading rules: `features/data/index.md`, `features/data/state.md`, and
 `namespace.md`.


### PR DESCRIPTION
## Description

Makes `@adobe/data-ai` deliver the **architecture rules**, not just the skills, so the bundle is self-sufficient in both Claude Code and Cursor. Previously the skills referenced rules (`the how is in the auto-loading rules…`) that never reached a consumer — the skills-only install was under-specified.

**Installer (`bin/cli.mjs`)** — `npx @adobe/data-ai install` now lays down two owned, namespaced, wipe-and-recopy dirs (each with a do-not-edit `CLAUDE.md`):
- skills → `.agents/skills/adobe-data-ai/` (Cursor / Codex / `.agents` agents)
- rules → `.claude/rules/adobe-data-ai/` (every agent; Claude auto-injects by `paths:`, others read by name — the skills notice points there)

Claude Code still gets skills from the marketplace plugin; rules install the same way for it.

**README** — rewritten as a concise install / update / use guide aimed at an installing agent: per-agent command blocks, `build-application` / `build-feature` up front, the rest named as discoverable.

**Skill fix** — `build-data` referenced `data/state.md`; corrected to `features/data/state.md`.

## Verification

Tested in scratch projects (not committed): clean install + update for both agents (user files untouched, strays wiped, version pinned), and a correct first `build-data` call producing a conventions-correct counter `data/` layer from **both** a Cursor-like agent (installed files only) and headless Claude (`--plugin-dir` + installed rules). Workspace lint + typecheck green.

Version rides in the unpublished `0.9.84` (npm latest is `0.9.83`); no bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)