### PR TITLE
data-ai README: agent-runnable Claude install + install-and-build one-liners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/README.md
+++ b/packages/data-ai/README.md
@@ -18,15 +18,22 @@ It installs two things:
 
 ## Install — Claude Code
 
-Skills load as a marketplace plugin; rules install into the project.
+Skills load as a marketplace plugin; rules install into the project. Run these
+three from a shell (agent-runnable):
 
 ```
-/plugin marketplace add adobe/data
-/plugin install adobe-data-ai@adobe-data-skills
+claude plugin marketplace add adobe/data --scope project
+claude plugin install adobe-data-ai@adobe-data-skills --scope project
 npx @adobe/data-ai@latest install
 ```
 
-- Skills → the `adobe-data-ai` plugin. **Update:** `/plugin` → update `adobe-data-ai`.
+In an interactive Claude session you can instead use the slash-command form of
+the first two — `/plugin marketplace add adobe/data` then
+`/plugin install adobe-data-ai@adobe-data-skills` — but an agent driving a shell
+should use the `claude plugin …` commands above (slash commands aren't
+shell-runnable).
+
+- Skills → the `adobe-data-ai` plugin. **Update:** `claude plugin update adobe-data-ai`.
 - Rules → `.claude/rules/adobe-data-ai/`. **Update:** re-run `npx @adobe/data-ai@latest install`.
 
 ## Install — Cursor (and Codex / other `.agents` agents)
@@ -58,3 +65,30 @@ by name when you want a single phase or a specialized flow: `build-data`,
 `build-ui`, `build-app-entry`; plus `build-game`, `meta-build` (phase-by-phase
 in subagents), `review` (audit output against the rules), and `structure`
 (reason about layout).
+
+## One-liner: install + build an app
+
+Paste one of these into a shell, replacing the quoted text with your own app
+description. It installs the bundle, then runs `build-application` headlessly on
+your prompt.
+
+**Cursor** (needs the `cursor-agent` CLI):
+
+```sh
+npx -y @adobe/data-ai@latest install && \
+cursor-agent --force -p "Use build-application to build: a todo app with tags, filtering, and undo"
+```
+
+**Claude Code** (needs the `claude` CLI):
+
+```sh
+npx -y @adobe/data-ai@latest install && \
+claude plugin marketplace add adobe/data --scope project && \
+claude plugin install adobe-data-ai@adobe-data-skills --scope project && \
+claude --dangerously-skip-permissions -p "Use build-application to build: a todo app with tags, filtering, and undo"
+```
+
+`--force` (Cursor) and `--dangerously-skip-permissions` (Claude) let the agent
+write files and run commands unattended — drop them to approve each step
+yourself, or swap the trailing `-p "…"` invocation for `build-feature`,
+`build-game`, or any other skill.

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.84",
+    "version": "0.9.85",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.84",
+    "version": "0.9.85",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Description

Follow-up to #151, from real npm-install tests of the published `0.9.84`.

**Agent-runnable Claude install.** The Claude section listed only `/plugin` *slash* commands, which an AI agent can't run from a shell — so an agent could only `npx` (skills land in `.agents/`, which Claude Code ignores). Now leads with the shell-runnable `claude plugin marketplace add … --scope project` / `claude plugin install … --scope project` form (verified end-to-end); slash commands kept as the interactive alternative.

**Install-and-build one-liners.** New section with paste-ready commands for Cursor (`cursor-agent --force -p`) and Claude (`claude --dangerously-skip-permissions -p`) that install the bundle and invoke `build-application` on a prompt in one line.

## Verification

Real installs from live npm (`npx @adobe/data-ai@latest install`) confirmed: Cursor path fully agent-followable; Claude plugin CLI install works project-scoped. README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)