### PR TITLE
fix(testing): allow Conformance.runSpec with zero case modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.93",
+    "version": "0.9.94",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.93",
+    "version": "0.9.94",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/testing/conformance/run-spec.empty-cases.test.ts
+++ b/packages/data/src/testing/conformance/run-spec.empty-cases.test.ts
@@ -1,0 +1,14 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Conformance } from "../index.js";
+
+// Module with `cases: []` opens an empty `describe` and used to leave the file
+// suite-less. Empty discovery registers a no-op so Vitest still collects a suite.
+Conformance.runSpec({
+  state: { create: () => ({ n: 0 }) },
+  transitions: {
+    "./empty-cases.ts": {
+      noop: (state: { n: number }) => state,
+      cases: [],
+    },
+  },
+});

--- a/packages/data/src/testing/conformance/run-spec.empty.test.ts
+++ b/packages/data/src/testing/conformance/run-spec.empty.test.ts
@@ -1,0 +1,11 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Conformance } from "../index.js";
+
+// Features with empty State and no pure transforms still call `runSpec` from a
+// dedicated `spec.test.ts`. Discovery with zero case modules must not leave the
+// file suite-less (Vitest: "No test suite found"). This file is the regression:
+// it is only this call — if empty discovery failed, vitest would fail the file.
+Conformance.runSpec({
+  state: { create: () => ({}) },
+  transitions: {},
+});

--- a/packages/data/src/testing/conformance/run-spec.test.ts
+++ b/packages/data/src/testing/conformance/run-spec.test.ts
@@ -1,0 +1,32 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Conformance } from "../index.js";
+
+// Non-empty discovery: one pure transition with co-located cases still pairs and
+// asserts as before (empty-discovery path must not break populated specs).
+const increment = (
+  state: { n: number },
+  { by }: { by: number },
+): { n: number } => ({ n: state.n + by });
+
+Conformance.runSpec({
+  state: { create: () => ({ n: 0 }) },
+  transitions: {
+    "./increment.ts": {
+      increment,
+      cases: [
+        {
+          name: "adds the delta over State.create()",
+          before: {},
+          args: { by: 2 },
+          after: { n: 2 },
+        },
+        {
+          name: "honors a non-default before delta",
+          before: { n: 10 },
+          args: { by: 1 },
+          after: { n: 11 },
+        },
+      ],
+    },
+  },
+});

--- a/packages/data/src/testing/conformance/run-spec.ts
+++ b/packages/data/src/testing/conformance/run-spec.ts
@@ -23,13 +23,36 @@ export interface SpecRunConfig {
   readonly label?: (path: string, fnName: string | undefined) => string;
 }
 
+type InvalidSuite = {
+  readonly kind: "invalid";
+  readonly path: string;
+  readonly label: string;
+  readonly exportNames: readonly string[];
+};
+
+type CasesSuite = {
+  readonly kind: "cases";
+  readonly label: string;
+  readonly fn: (...args: unknown[]) => unknown;
+  readonly cases: readonly unknown[];
+};
+
+type Suite = InvalidSuite | CasesSuite;
+
 // The single pure-spec test for every transform AND derivation in a `data/state/`
 // folder. It auto-discovers each file that exports `cases`, requires that file to
 // export exactly its function plus `cases`, and dispatches on case shape: a `value`
 // case checks a derivation `(state) => value`; otherwise a transition `(state,
 // args) => state`, whose declared `effects` on injected services are also asserted.
 // A service-injected transition is async, so results are awaited uniformly.
+//
+// Features with empty `State` and no pure transforms still keep a one-line
+// `spec.test.ts` that calls `runSpec`. When discovery finds zero case modules (or
+// only empty `cases: []` arrays), Vitest would otherwise fail the file with
+// "No test suite found" — so we register a single no-op so empty discovery is a
+// valid outcome, not an error.
 export const runSpec = (config: SpecRunConfig): void => {
+  const suites: Suite[] = [];
   for (const [path, module] of Object.entries(config.transitions)) {
     const exportNames = Object.keys(module);
     if (!exportNames.includes("cases")) continue;
@@ -40,22 +63,43 @@ export const runSpec = (config: SpecRunConfig): void => {
     const label = config.label
       ? config.label(path, fnName)
       : `State.${fnName ?? path}`;
-    describe(label, () => {
-      if (exportNames.length !== 2 || functionNames.length !== 1) {
+    if (exportNames.length !== 2 || functionNames.length !== 1) {
+      suites.push({ kind: "invalid", path, label, exportNames });
+      continue;
+    }
+    const cases = module["cases"] as readonly unknown[];
+    // Empty `cases: []` is not a suite (and would open a Vitest describe with no
+    // tests, which fails even when this file has other suites).
+    if (cases.length === 0) continue;
+    suites.push({
+      kind: "cases",
+      label,
+      fn: module[functionNames[0]!] as (...args: unknown[]) => unknown,
+      cases,
+    });
+  }
+
+  if (suites.length === 0) {
+    it("has no pure transitions to specify", () => {
+      // intentional no-op — empty discovery is a valid feature shape
+    });
+    return;
+  }
+
+  for (const suite of suites) {
+    describe(suite.label, () => {
+      if (suite.kind === "invalid") {
         it("exports exactly its function and `cases`", () => {
           throw new Error(
-            `${path} exports [${exportNames.join(", ")}] — expected one function + cases`,
+            `${suite.path} exports [${suite.exportNames.join(", ")}] — expected one function + cases`,
           );
         });
         return;
       }
-      // Runtime invariant: a participating file exports one function and its cases.
-      const fn = module[functionNames[0]] as (...args: unknown[]) => unknown;
-      const cases = module["cases"] as readonly unknown[];
-      for (const testCase of cases) {
+      for (const testCase of suite.cases) {
         if (isDerivationCase(testCase)) {
           it(testCase.name, () =>
-            assert(fn(testCase.input), testCase.value, config.match),
+            assert(suite.fn(testCase.input), testCase.value, config.match),
           );
           continue;
         }
@@ -75,7 +119,7 @@ export const runSpec = (config: SpecRunConfig): void => {
             ...(config.state?.create() ?? {}),
             ...(tc.before as Record<string, unknown>),
           };
-          const result = (await fn(before, args)) as Record<string, unknown>;
+          const result = (await suite.fn(before, args)) as Record<string, unknown>;
           assert(
             { ...before, ...result },
             { ...before, ...(tc.after as Record<string, unknown>) },


### PR DESCRIPTION
## Summary
- `Conformance.runSpec` previously registered no Vitest suites when discovery found no modules exporting `cases`, so empty-State `spec.test.ts` files failed with "No test suite found".
- Empty discovery now registers a single no-op (`has no pure transitions to specify`), matching the intended "always keep a one-line `spec.test.ts`" pattern for features without pure transforms.
- Skips empty `cases: []` modules so they do not open suite-less `describe` blocks.
- Adds regression tests for empty transitions, empty `cases` arrays, and a normal transition pairing.

## Test plan
- [x] `pnpm exec vitest --run --project node src/testing/conformance/run-spec` in `packages/data`
- [ ] Confirm a feature with empty State + only `Conformance.runSpec({ transitions })` passes without `--passWithNoTests`


Made with [Cursor](https://cursor.com)