### PR TITLE
fix(data): canonical observe.select cache key so Set includes don't collide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.94",
+    "version": "0.9.95",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.94",
+    "version": "0.9.95",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.94",
+  "version": "0.9.95",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/observe-select-entities.test.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.test.ts
@@ -562,6 +562,64 @@ describe("observeSelectEntities", () => {
         });
     });
 
+    describe("Set-based include (archetype.components)", () => {
+        // `observe.select` accepts `ReadonlySet<string>` — exactly the shape
+        // `archetype.components` has. Every other test in this file passes an
+        // array, so the Set path is unexercised. The select-observe cache keys
+        // on `JSON.stringify({ include, options })`, and `JSON.stringify(aSet)`
+        // is always `"{}"`, so two selects made with *different* component Sets
+        // collide on one cache key and the second is served the first's observe
+        // function. With a single Set-based subscription (a minimal chain) the
+        // collision is invisible; with two or more (a composed graph) it bites.
+
+        it("should return distinct results for selects made with different component Sets", () => {
+            const positionObserver = vi.fn();
+            const healthObserver = vi.fn();
+
+            database.observe.select(new Set(["position"]))(positionObserver);
+            database.observe.select(new Set(["health"]))(healthObserver);
+
+            const positionResult = positionObserver.mock.calls[0][0];
+            const healthResult = healthObserver.mock.calls[0][0];
+
+            expect(positionResult).toContain(entities.pos1);
+            expect(positionResult).not.toContain(entities.health1);
+
+            expect(healthResult).toContain(entities.health1);
+            expect(healthResult).not.toContain(entities.pos1);
+        });
+
+        it("should re-emit on membership contraction for a Set-based select after another Set-based select was made", async () => {
+            // A prior subscription keyed on a different component Set poisons the
+            // shared cache key, so the select below is wrongly served it.
+            database.observe.select(new Set(["position"]))(vi.fn());
+
+            const observer = vi.fn();
+            const unsubscribe = database.observe.select(new Set(["position", "health"]))(observer);
+
+            // Initial emission looks correct: posHealth1 has position (the
+            // poisoned observe's include), so it is present.
+            expect(observer).toHaveBeenCalledTimes(1);
+            expect(observer.mock.calls[0][0]).toContain(entities.posHealth1);
+
+            // Remove health: posHealth1 migrates out of the position+health set.
+            database.transactions.updateEntity({
+                entity: entities.posHealth1,
+                values: { health: undefined }
+            });
+
+            await Promise.resolve();
+
+            // Must re-emit without posHealth1. With the collapsed cache key the
+            // subscription is actually observing {position}, for which removing
+            // health is a no-op, so no notification fires.
+            expect(observer).toHaveBeenCalledTimes(2);
+            expect(observer.mock.calls[1][0]).not.toContain(entities.posHealth1);
+
+            unsubscribe();
+        });
+    });
+
     describe("Filtering and ordering", () => {
         it("should support where clause filtering", () => {
             const observer = vi.fn();

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -150,7 +150,7 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
         include: readonly Include[] | ReadonlySet<string>,
         options?: EntitySelectOptions<C, Pick<C & RequiredComponents & OptionalComponents, Include>>
     ) => {
-        const key = JSON.stringify({ include, options });
+        const key = canonicalSelectKey(include, options);
         let observeFunction = cachedSelectObserveFunctions.get(key);
         if (!observeFunction) {
             observeFunction = Observe.withCache(createSelectObserveFunction(include, options));
@@ -159,3 +159,45 @@ export const observeSelectEntities = <C extends object>(store: ReadonlyStore<C, 
         return observeFunction;
     }
 }
+
+// Segment/element delimiters. Component names are schema keys (identifiers), so
+// these control chars cannot occur inside one, making the key unambiguous.
+const SECTION = "\u0001";
+const ELEMENT = "\u0000";
+
+/**
+ * Canonical string key for a `(include, options)` query so semantically-equal
+ * queries share one cached Observe.
+ *
+ * Not `JSON.stringify({ include, options })`: a `Set` (the shape of
+ * `archetype.components`) serializes to `"{}"`, collapsing every set-based
+ * select onto one key. Not a WeakMap identity cache either: it would only help
+ * stable references and measurably pessimizes fresh-literal callers, on a
+ * subscription-setup path where absolute cost is already sub-microsecond.
+ *
+ * `include`/`exclude` are set-like (sorted, so order and array-vs-Set don't
+ * matter); `where` is a conjunction (keys sorted, values JSON-serialized);
+ * `order` is a sort-priority sequence (preserved as written).
+ */
+const canonicalSelectKey = <C extends object, T extends object>(
+    include: readonly string[] | ReadonlySet<string>,
+    options?: EntitySelectOptions<C, T>,
+): string => {
+    let key = [...include].sort().join(ELEMENT);
+    if (!options) return key;
+    if (options.exclude && options.exclude.length > 0) {
+        key += SECTION + "x" + [...options.exclude].sort().join(ELEMENT);
+    }
+    if (options.where) {
+        const parts = Object.entries(options.where)
+            .map(([k, v]) => k + "=" + JSON.stringify(v))
+            .sort();
+        if (parts.length > 0) key += SECTION + "w" + parts.join(ELEMENT);
+    }
+    if (options.order) {
+        const parts = Object.entries(options.order)
+            .map(([k, v]) => k + "=" + (v ? "1" : "0"));
+        if (parts.length > 0) key += SECTION + "o" + parts.join(ELEMENT);
+    }
+    return key;
+};


### PR DESCRIPTION
## Description

`observe.select` cached its per-query `Observe` functions under `JSON.stringify({ include, options })`. Because `include` may be a `ReadonlySet` — exactly the shape of `archetype.components` — and `JSON.stringify(aSet)` is always `"{}"`, every set-based select collapsed onto a single cache key. A second set-based select was then served the **first** one's observe function.

This explains the reported minimal-vs-composed divergence: with a single set-based subscription (a minimal chain) the collision is invisible; in a composed graph an earlier set-based select poisons the shared key, so a later `observe.select(TrackItem.components)` silently watches the wrong include set and membership contraction (`update(entity, { orderedChildOf: undefined })`) never re-emits (`before:1, after:1`). Every existing test passed an array, so the Set path was unexercised.

### Fix

Replace the key builder with a hand-built canonical key:
- `include` / `exclude` — sorted (order- and array-vs-Set-agnostic), killing the collision.
- `where` — keys sorted, values JSON-serialized (so equivalent filters dedup too).
- `order` — sequence preserved (it's a sort priority).

Chosen over a normalized `JSON.stringify` (the quick fix) and over a WeakMap identity cache: the hand-built key is ~2.3x faster than stringify in both stable-ref and fresh-literal microbenchmarks and pessimizes neither, on a subscription-setup path where absolute cost is already sub-microsecond. A WeakMap identity cache hits 127 M/s on stable refs but drops to stringify-level on fresh literals — the wrong trade for a cold path.

### Tests

New `Set-based include` block in `observe-select-entities.test.ts` (red before, green after):
- distinct component Sets return distinct results (direct proof of the collision);
- membership contraction re-emits for a Set-based select even after another set-based select was made (the reported repro).

Full `@adobe/data` suite (3001 tests) and monorepo typecheck pass.

## Related PRs

Follows up #144 (membership-contraction re-emit).