### PR TITLE
feat(data)!: preload flag for AsyncDataService.createLazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # @adobe/data
+
 Adobe Data Oriented Programming Library
 
 ## Documentation
@@ -116,6 +117,7 @@ For our purposes, `Data` is immutable `JSON` (de)serializable objects and primit
 ### Why immutable Data?
 
 We prefer Data because it is easy to:
+
 - serialize
 - deserialize
 - inspect
@@ -124,14 +126,15 @@ We prefer Data because it is easy to:
 - validate
 
 We prefer immutable Data because it is easy to:
+
 - reason about
 - avoid side effects
 - avoid defensive copying
 - use for pure function arguments and return values
 - use with concurrency
 - memoize results
-    - use as cache key (stringified)
-    - use as cache value
+  - use as cache key (stringified)
+  - use as cache value
 
 ### What is Data Oriented Design?
 
@@ -191,10 +194,11 @@ export type Unobserve = () => void;
 ```
 
 An Observable can be thought of sort of like a Promise but with a few important differences.
+
 - A Promise only yields a single value, an Observable yields a sequence of values.
 - A Promise can reject with an error, an Observable can not. (It could yield type `MyResult | MyError` though.)
 - A Promise can only resolve asynchronously, an Observable *may* yield an initial result synchronously.
-    - An Observable is allowed to call the Callback callback function immediately upon observation if it has a value.
+  - An Observable is allowed to call the Callback callback function immediately upon observation if it has a value.
 - A Promise begins executing immediately, an Observable may lazily wait for a first observer before taking any action.
 - An Observable can be unobserved.
 
@@ -260,6 +264,7 @@ The `BlobStore` interface and corresponding `blobStore` exported instance provid
 
 `BlobRef`s have a number of advantages over directly using blobs.
 `BlobRef`s are:
+
 - small json objects
 - deterministic for each `Blob` based on mime type and content.
 - suitable for persistence to locations with limited size.
@@ -302,3 +307,46 @@ Sanders Mertens covers this thoroughly in his ECS FAQ:
 [https://github.com/SanderMertens/ecs-faq?tab=readme-ov-file#what-is-ecs](https://github.com/SanderMertens/ecs-faq?tab=readme-ov-file#what-is-ecs)
 
 In addition to the standard Entity, Component, and System definitions, we also use the term **Resource** — a global singleton value defined on the ECS itself, not attached to any specific entity.
+
+## Corporate contributors
+
+If your primary GitHub account is a corporate / Enterprise Managed User (EMU) account, it may be unable to fork or push to public repositories like this one. The fix is to contribute from a separate personal GitHub identity on the same machine, using SSH host aliases so each identity uses its own key.
+
+**Problem:** one machine, multiple GitHub identities (e.g. corporate vs. personal), needing a different SSH key per identity — but `git@github.com` only supports one key per config entry.
+
+**Solution:** define extra `Host` aliases in `~/.ssh/config` that all point at the real `github.com`, each pinned to a different key with `IdentitiesOnly yes`:
+
+```sshconfig
+# Default identity (e.g. your corporate account)
+Host github.com
+  HostName github.com
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+
+# Alternate identity (e.g. your personal account)
+Host github.com-personal
+  HostName github.com
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519_personal
+  IdentitiesOnly yes
+```
+
+Then pick the identity by swapping the host in the remote URL:
+
+```sh
+git@github.com-personal:adobe/data.git   # uses the personal-account key
+git@github.com:adobe/data.git            # uses the default key
+```
+
+`IdentitiesOnly yes` is required — without it, `ssh-agent` may offer the wrong key first and authenticate against the wrong account.
+
+**Setup:**
+
+1. Generate a separate SSH key per GitHub identity and add each public key to the corresponding GitHub account.
+2. Add one host-alias block per non-default identity to `~/.ssh/config`, as above.
+3. For any repo that should use a non-default identity, set its remote to the aliased host (`git remote set-url origin git@github.com-personal:adobe/data.git`), and set that repo's local `user.email` to the matching account.
+
+The `-personal` suffix is just an arbitrary alias name — any label works as long as `HostName` maps it back to `github.com`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.104",
+    "version": "0.10.0",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.104",
+    "version": "0.10.0",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.104",
+  "version": "0.10.0",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/service/async-data-service/README.md
+++ b/packages/data/src/service/async-data-service/README.md
@@ -5,6 +5,7 @@ Utilities for working with asynchronous data services.
 ## Overview
 
 AsyncDataServices are services that only contain:
+
 - `Observe<Data>` properties
 - Functions that accept only `Data` arguments and return:
   - `Observe<Data>`
@@ -38,19 +39,19 @@ interface MyService extends Service {
 type Check = Assert<AsyncDataService.IsValid<MyService>>;
 ```
 
-### `AsyncDataService.createLazy(load, properties)`
+### `AsyncDataService.createLazy({ load, properties, preload? })`
 
-Creates a lazy-loading wrapper factory for a service. Returns a factory function that creates service instances. The real service is only loaded when first accessed. TypeScript automatically infers service and argument types.
+Creates a lazy-loading wrapper factory for a service. Returns a factory function that creates service instances. The real service is only loaded when first accessed (or, with `preload: true`, at browser idle). TypeScript automatically infers service and argument types.
 
 ```typescript
 // Define the factory
-const createLazyService = AsyncDataService.createLazy(
-  () => import('./my-service').then(m => m.createService()),
-  {
+const createLazyService = AsyncDataService.createLazy({
+  load: () => import('./my-service').then(m => m.createService()),
+  properties: {
     data: 'observe',
     fetchData: 'fn:promise'
   }
-);
+});
 
 // Create instances
 const service = createLazyService();
@@ -59,15 +60,16 @@ const service = createLazyService();
 **With Constructor Args:**
 
 ```typescript
-const createLazyService = AsyncDataService.createLazy(
-  (config: Config) => import('./my-service').then(m => m.createService(config)),
-  { data: 'observe', fetch: 'fn:promise' }
-);
+const createLazyService = AsyncDataService.createLazy({
+  load: (config: Config) => import('./my-service').then(m => m.createService(config)),
+  properties: { data: 'observe', fetch: 'fn:promise' }
+});
 
 const service = createLazyService({ apiUrl: '...' });
 ```
 
 **Features:**
+
 - ✅ Full type inference (no generic type parameters needed)
 - ✅ Lazy loading on first property access
 - ✅ Call queuing for functions (all calls execute in order after load)

--- a/packages/data/src/service/async-data-service/create-lazy.md
+++ b/packages/data/src/service/async-data-service/create-lazy.md
@@ -13,13 +13,26 @@ import { AsyncDataService } from "@adobe/data/service";
 ## API Surface
 
 ```typescript
-AsyncDataService.createLazy(
+AsyncDataService.createLazy({
   load: (...args: any[]) => Promise<Service>,
-  properties: { [key: string]: PropertyDescriptor }
-): (...args: Args) => Service
+  properties: { [key: string]: PropertyDescriptor },
+  preload?: boolean
+}): (...args: Args) => Service
 ```
 
 Returns a **factory function** that creates lazy service instances. TypeScript automatically infers both the service type and argument types from the `load` function.
+
+### Preloading
+
+By default a lazy service loads on first property access. Set `preload: true` to warm it at browser idle instead — it schedules the load via the browser's `requestIdleCallback`, so the first real call never races a cold load. Defaults to `false`, and is a no-op where `requestIdleCallback` is unavailable (SSR / Node / older browsers).
+
+```typescript
+AsyncDataService.createLazy({
+  load: () => import('./analytics').then(m => m.create()),
+  properties: { send: 'fn:void', pageload: 'fn:void' },
+  preload: true   // warm at browser idle
+});
+```
 
 ### Descriptor Format
 
@@ -71,15 +84,15 @@ interface AuthService extends Service {
 }
 
 // Define the lazy factory
-const createLazyAuthService = AsyncDataService.createLazy(
-  () => import('./auth-service').then(m => m.createAuthService()),
-  {
+const createLazyAuthService = AsyncDataService.createLazy({
+  load: () => import('./auth-service').then(m => m.createAuthService()),
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     signIn: 'fn:promise',
     signOut: 'fn:void'
   }
-);
+});
 
 // Create an instance
 const authService = createLazyAuthService();
@@ -101,13 +114,13 @@ type ServiceConfig = {
 };
 
 // Define the lazy factory
-const createLazyConfigService = AsyncDataService.createLazy(
-  (config: ServiceConfig) => import('./config-service').then(m => m.create(config)),
-  {
+const createLazyConfigService = AsyncDataService.createLazy({
+  load: (config: ServiceConfig) => import('./config-service').then(m => m.create(config)),
+  properties: {
     config: 'observe',
     fetch: 'fn:promise'
   }
-);
+});
 
 // Create instances with different configs
 const prodService = createLazyConfigService({ apiUrl: 'https://api.prod.com' });
@@ -136,16 +149,16 @@ interface ComplexService extends Service {
   clearCache: () => void;
 }
 
-const createLazyComplexService = AsyncDataService.createLazy(
-  () => import('./complex').then(m => m.createService()),
-  {
+const createLazyComplexService = AsyncDataService.createLazy({
+  load: () => import('./complex').then(m => m.createService()),
+  properties: {
     status: 'observe',
     selectById: 'fn:observe',
     streamEvents: 'fn:generator',
     fetchData: 'fn:promise',
     clearCache: 'fn:void'
   }
-);
+});
 
 const service = createLazyComplexService();
 ```
@@ -156,46 +169,46 @@ const service = createLazyComplexService();
 
 ```typescript
 // ❌ Error: Property 'signOut' is missing
-const error = AsyncDataService.createLazy(
-  () => import('./auth').then(m => m.create()),
-  {
+const error = AsyncDataService.createLazy({
+  load: () => import('./auth').then(m => m.create()),
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     signIn: 'fn:promise'
     // Missing: signOut - TypeScript will error
   }
-);
+});
 ```
 
 ### Wrong Descriptor Type
 
 ```typescript
 // ❌ Error: Type '"fn:observe"' is not assignable to type '"observe"'
-const error = AsyncDataService.createLazy(
-  () => import('./auth').then(m => m.create()),
-  {
+const error = AsyncDataService.createLazy({
+  load: () => import('./auth').then(m => m.create()),
+  properties: {
     isSignedIn: 'fn:observe', // Wrong: should be 'observe'
     accessToken: 'observe',
     signIn: 'fn:promise',
     signOut: 'fn:void'
   }
-);
+});
 ```
 
 ### Extra Property
 
 ```typescript
 // ❌ Error: 'unknownProp' does not exist in type
-const error = AsyncDataService.createLazy(
-  () => import('./auth').then(m => m.create()),
-  {
+const error = AsyncDataService.createLazy({
+  load: () => import('./auth').then(m => m.create()),
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     signIn: 'fn:promise',
     signOut: 'fn:void',
     unknownProp: 'observe' // Extra: doesn't exist in service
   }
-);
+});
 ```
 
 ## Behavior (Queue Strategy)
@@ -227,6 +240,7 @@ type CheckValidDataService = Assert<AsyncDataService.IsValid<MyService>>;
 ## Testing
 
 See `create-lazy.test.ts` for comprehensive type safety tests including:
+
 - Valid usage with all property types
 - Error cases for missing/wrong/extra properties
 - Services with and without constructor args

--- a/packages/data/src/service/async-data-service/create-lazy.test.ts
+++ b/packages/data/src/service/async-data-service/create-lazy.test.ts
@@ -117,9 +117,9 @@ type _CheckRecognitionService = Assert<IsValid<RecognitionService>>;
 // ============================================================================
 
 // ✅ Test 1: Complete descriptor for SimpleAuthService
-const validAuth = createLazy(
-  () => Promise.resolve({} as SimpleAuthService),
-  {
+const validAuth = createLazy({
+  load: () => Promise.resolve({} as SimpleAuthService),
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     userProfile: 'observe',
@@ -129,27 +129,27 @@ const validAuth = createLazy(
     signIn: 'fn:promise',
     signOut: 'fn:promise'
   }
-);
+});
 
 // ✅ Test 2: Service with function returning Observe
-const validObserveFn = createLazy(
-  () => Promise.resolve({} as ServiceWithObserveFn),
-  {
+const validObserveFn = createLazy({
+  load: () => Promise.resolve({} as ServiceWithObserveFn),
+  properties: {
     allUsers: 'observe',
     selectUser: 'fn:observe',
     fetchData: 'fn:promise'
   }
-);
+});
 
 // ✅ Test 3: Service with AsyncGenerator
-const validGenerator = createLazy(
-  () => Promise.resolve({} as ServiceWithGenerator),
-  {
+const validGenerator = createLazy({
+  load: () => Promise.resolve({} as ServiceWithGenerator),
+  properties: {
     status: 'observe',
     streamEvents: 'fn:generator',
     cancel: 'fn:void'
   }
-);
+});
 
 // ✅ Test 4: Service with constructor args
 type ServiceConfig = {
@@ -157,27 +157,38 @@ type ServiceConfig = {
   timeout?: number;
 };
 
-const validWithArgs = createLazy(
-  (args: ServiceConfig) => {
+const validWithArgs = createLazy({
+  load: (args: ServiceConfig) => {
     // args is properly typed as ServiceConfig
     console.log(args.apiUrl);
     return Promise.resolve({} as ConfigurableService);
   },
-  {
+  properties: {
     config: 'observe',
     fetch: 'fn:promise'
   }
-);
+});
+
+// ✅ Test 4b: preload flag is accepted
+const validWithPreload = createLazy({
+  load: () => Promise.resolve({} as ServiceWithObserveFn),
+  properties: {
+    allUsers: 'observe',
+    selectUser: 'fn:observe',
+    fetchData: 'fn:promise'
+  },
+  preload: true
+});
 
 // ============================================================================
 // ERROR TESTS (These should produce TypeScript errors)
 // ============================================================================
 
 // ❌ Test 5: Missing property 'refreshToken'
-const errorMissing = createLazy(
-  () => Promise.resolve({} as SimpleAuthService),
+const errorMissing = createLazy({
+  load: () => Promise.resolve({} as SimpleAuthService),
   // @ts-expect-error - Missing property 'refreshToken' in descriptor
-  {
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     userProfile: 'observe',
@@ -187,12 +198,12 @@ const errorMissing = createLazy(
     signIn: 'fn:promise',
     signOut: 'fn:promise'
   }
-);
+});
 
 // ❌ Test 6: Wrong descriptor type (observe property marked as fn:observe)
-const errorWrongType1 = createLazy(
-  () => Promise.resolve({} as SimpleAuthService),
-  {
+const errorWrongType1 = createLazy({
+  load: () => Promise.resolve({} as SimpleAuthService),
+  properties: {
     // @ts-expect-error - Wrong descriptor type
     isSignedIn: 'fn:observe', // WRONG: should be 'observe'
     accessToken: 'observe',
@@ -203,12 +214,12 @@ const errorWrongType1 = createLazy(
     signIn: 'fn:promise',
     signOut: 'fn:promise'
   }
-);
+});
 
 // ❌ Test 7: Wrong descriptor type (void function marked as fn:promise)
-const errorWrongType2 = createLazy(
-  () => Promise.resolve({} as SimpleAuthService),
-  {
+const errorWrongType2 = createLazy({
+  load: () => Promise.resolve({} as SimpleAuthService),
+  properties: {
     isSignedIn: 'observe',
     accessToken: 'observe',
     userProfile: 'observe',
@@ -219,41 +230,41 @@ const errorWrongType2 = createLazy(
     signIn: 'fn:promise',
     signOut: 'fn:promise'
   }
-);
+});
 
 // ❌ Test 8: Extra property that doesn't exist in service
-const errorExtra = createLazy(
-  () => Promise.resolve({} as ServiceWithObserveFn),
-  {
+const errorExtra = createLazy({
+  load: () => Promise.resolve({} as ServiceWithObserveFn),
+  properties: {
     allUsers: 'observe',
     selectUser: 'fn:observe',
     fetchData: 'fn:promise',
     // @ts-expect-error - Extra property
     unknownProperty: 'observe' // EXTRA: doesn't exist in service
   }
-);
+});
 
 // ❌ Test 9: Wrong descriptor for fn:observe (marked as observe)
-const errorObserveFn = createLazy(
-  () => Promise.resolve({} as ServiceWithObserveFn),
-  {
+const errorObserveFn = createLazy({
+  load: () => Promise.resolve({} as ServiceWithObserveFn),
+  properties: {
     allUsers: 'observe',
     // @ts-expect-error - Wrong descriptor type
     selectUser: 'observe', // WRONG: should be 'fn:observe'
     fetchData: 'fn:promise'
   }
-);
+});
 
 // ❌ Test 10: Wrong descriptor for generator
-const errorGenerator = createLazy(
-  () => Promise.resolve({} as ServiceWithGenerator),
-  {
+const errorGenerator = createLazy({
+  load: () => Promise.resolve({} as ServiceWithGenerator),
+  properties: {
     status: 'observe',
     // @ts-expect-error - Wrong descriptor type
     streamEvents: 'fn:promise', // WRONG: should be 'fn:generator'
     cancel: 'fn:void'
   }
-);
+});
 
 // ============================================================================
 // RUNTIME TESTS
@@ -264,7 +275,7 @@ describe('createLazy', () => {
     interface TestService extends Service {
       value: Observe<string>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -274,21 +285,21 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { value: 'observe' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { value: 'observe' }
+    });
+
     assert({
       given: 'createLazy is called',
       should: 'return a factory function',
       actual: typeof factory,
       expected: 'function'
     });
-    
+
     const service = factory();
-    
+
     assert({
       given: 'factory function is called',
       should: 'return a service with serviceName',
@@ -296,12 +307,12 @@ describe('createLazy', () => {
       expected: 'string'
     });
   });
-  
+
   test('observe property', async () => {
     interface TestService extends Service {
       value: Observe<string>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -311,37 +322,37 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { value: 'observe' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { value: 'observe' }
+    });
+
     const service = factory();
-    
+
     let receivedValue: string | null = null;
     const unobserve = service.value((value) => {
       receivedValue = value;
     });
-    
+
     // Wait for async load
     await new Promise(resolve => setTimeout(resolve, 10));
-    
+
     assert({
       given: 'observe property is subscribed',
       should: 'receive value from real service after load',
       actual: receivedValue,
       expected: 'test-value'
     });
-    
+
     unobserve();
   });
-  
+
   test('observe property returns same instance', async () => {
     interface TestService extends Service {
       value: Observe<string>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -351,17 +362,17 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { value: 'observe' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { value: 'observe' }
+    });
+
     const service = factory();
-    
+
     const observe1 = service.value;
     const observe2 = service.value;
-    
+
     assert({
       given: 'observe property is accessed multiple times',
       should: 'return the same Observe instance',
@@ -369,12 +380,12 @@ describe('createLazy', () => {
       expected: true
     });
   });
-  
+
   test('promise function', async () => {
     interface TestService extends Service {
       fetchData: (id: string) => Promise<{ readonly value: string }>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -383,16 +394,16 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { fetchData: 'fn:promise' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { fetchData: 'fn:promise' }
+    });
+
     const service = factory();
-    
+
     const result = await service.fetchData('123');
-    
+
     assert({
       given: 'promise function is called',
       should: 'return result from real service',
@@ -400,14 +411,14 @@ describe('createLazy', () => {
       expected: 'data-123'
     });
   });
-  
+
   test('promise function queuing', async () => {
     interface TestService extends Service {
       fetchData: (id: string) => Promise<string>;
     }
-    
+
     const calls: string[] = [];
-    
+
     const createTestService = (): Promise<TestService> => {
       return new Promise(resolve => {
         setTimeout(() => {
@@ -421,28 +432,28 @@ describe('createLazy', () => {
         }, 50);
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { fetchData: 'fn:promise' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { fetchData: 'fn:promise' }
+    });
+
     const service = factory();
-    
+
     // Call multiple times before service loads
     const p1 = service.fetchData('a');
     const p2 = service.fetchData('b');
     const p3 = service.fetchData('c');
-    
+
     const results = await Promise.all([p1, p2, p3]);
-    
+
     assert({
       given: 'multiple calls made before service loads',
       should: 'execute all calls in order',
       actual: calls.join(','),
       expected: 'a,b,c'
     });
-    
+
     assert({
       given: 'queued calls complete',
       should: 'return correct results',
@@ -462,10 +473,10 @@ describe('createLazy', () => {
         fetchData: async (id: string) => `result-${id}`
       });
 
-    const factory = createLazy(
-      createTestService,
-      { fetchData: 'fn:promise' }
-    );
+    const factory = createLazy({
+      load: createTestService,
+      properties: { fetchData: 'fn:promise' }
+    });
 
     const service = factory();
 
@@ -493,25 +504,25 @@ describe('createLazy', () => {
       expected: 'result-third'
     });
   });
-  
+
   test('promise function returns same instance', async () => {
     interface TestService extends Service {
       fetchData: (id: string) => Promise<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         fetchData: async (id: string) => `result-${id}`
       }),
-      { fetchData: 'fn:promise' }
-    );
-    
+      properties: { fetchData: 'fn:promise' }
+    });
+
     const service = factory();
-    
+
     const fn1 = service.fetchData;
     const fn2 = service.fetchData;
-    
+
     assert({
       given: 'promise function property is accessed multiple times',
       should: 'return the same function instance',
@@ -519,35 +530,35 @@ describe('createLazy', () => {
       expected: true
     });
   });
-  
+
   test('promise function calls return different promises', async () => {
     interface TestService extends Service {
       fetchData: (id: string) => Promise<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         fetchData: async (id: string) => `result-${id}`
       }),
-      { fetchData: 'fn:promise' }
-    );
-    
+      properties: { fetchData: 'fn:promise' }
+    });
+
     const service = factory();
-    
+
     const promise1 = service.fetchData('id-1');
     const promise2 = service.fetchData('id-1');
     const promise3 = service.fetchData('id-2');
-    
+
     assert({
       given: 'promise function is called multiple times',
       should: 'return different Promise instances',
       actual: promise1 !== promise2 && promise1 !== promise3,
       expected: true
     });
-    
+
     const results = await Promise.all([promise1, promise2, promise3]);
-    
+
     assert({
       given: 'promise function called with different args',
       should: 'resolve to correct values independently',
@@ -555,14 +566,14 @@ describe('createLazy', () => {
       expected: 'result-id-1,result-id-1,result-id-2'
     });
   });
-  
+
   test('void function', async () => {
     interface TestService extends Service {
       track: (event: string) => void;
     }
-    
+
     const events: string[] = [];
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -571,20 +582,20 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { track: 'fn:void' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { track: 'fn:void' }
+    });
+
     const service = factory();
-    
+
     service.track('event-1');
     service.track('event-2');
-    
+
     // Wait for async load and execution
     await new Promise(resolve => setTimeout(resolve, 10));
-    
+
     assert({
       given: 'void functions are called',
       should: 'execute all calls in order after load',
@@ -592,12 +603,12 @@ describe('createLazy', () => {
       expected: 'event-1,event-2'
     });
   });
-  
+
   test('observe function', async () => {
     interface TestService extends Service {
       selectUser: (id: string) => Observe<string>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -607,54 +618,54 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { selectUser: 'fn:observe' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { selectUser: 'fn:observe' }
+    });
+
     const service = factory();
-    
+
     let receivedValue: string | null = null;
     const observe = service.selectUser('123');
     const unobserve = observe((value) => {
       receivedValue = value;
     });
-    
+
     // Wait for async load
     await new Promise(resolve => setTimeout(resolve, 10));
-    
+
     assert({
       given: 'observe function is called and subscribed',
       should: 'receive value from real service',
       actual: receivedValue,
       expected: 'user-123'
     });
-    
+
     unobserve();
   });
-  
+
   test('observe function returns same instance', async () => {
     interface TestService extends Service {
       selectUser: (id: string) => Observe<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         selectUser: (id: string) => (notify: (value: string) => void) => {
           notify(`user-${id}`);
           return () => {};
         }
       }),
-      { selectUser: 'fn:observe' }
-    );
-    
+      properties: { selectUser: 'fn:observe' }
+    });
+
     const service = factory();
-    
+
     const fn1 = service.selectUser;
     const fn2 = service.selectUser;
-    
+
     assert({
       given: 'observe function property is accessed multiple times',
       should: 'return the same function instance',
@@ -662,36 +673,36 @@ describe('createLazy', () => {
       expected: true
     });
   });
-  
+
   test('observe function calls return different instances', async () => {
     interface TestService extends Service {
       selectUser: (id: string) => Observe<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         selectUser: (id: string) => (notify: (value: string) => void) => {
           notify(`user-${id}`);
           return () => {};
         }
       }),
-      { selectUser: 'fn:observe' }
-    );
-    
+      properties: { selectUser: 'fn:observe' }
+    });
+
     const service = factory();
-    
+
     const observe1 = service.selectUser('id-1');
     const observe2 = service.selectUser('id-1');
     const observe3 = service.selectUser('id-2');
-    
+
     assert({
       given: 'observe function is called multiple times with same args',
       should: 'return different Observe instances',
       actual: observe1 !== observe2,
       expected: true
     });
-    
+
     assert({
       given: 'observe function is called with different args',
       should: 'return different Observe instances',
@@ -699,52 +710,52 @@ describe('createLazy', () => {
       expected: true
     });
   });
-  
+
   test('observe function calls with different args work independently', async () => {
     interface TestService extends Service {
       selectUser: (id: string) => Observe<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         selectUser: (id: string) => (notify: (value: string) => void) => {
           notify(`user-${id}`);
           return () => {};
         }
       }),
-      { selectUser: 'fn:observe' }
-    );
-    
+      properties: { selectUser: 'fn:observe' }
+    });
+
     const service = factory();
-    
+
     const values: string[] = [];
-    
+
     const observe1 = service.selectUser('id-1');
     const unobserve1 = observe1((value) => values.push(`obs1:${value}`));
-    
+
     const observe2 = service.selectUser('id-2');
     const unobserve2 = observe2((value) => values.push(`obs2:${value}`));
-    
+
     // Wait for async load
     await new Promise(resolve => setTimeout(resolve, 10));
-    
+
     assert({
       given: 'multiple observe function calls with different args',
       should: 'each receive their own values independently',
       actual: values.sort().join(','),
       expected: 'obs1:user-id-1,obs2:user-id-2'
     });
-    
+
     unobserve1();
     unobserve2();
   });
-  
+
   test('generator function', async () => {
     interface TestService extends Service {
       streamData: () => AsyncGenerator<number>;
     }
-    
+
     const createTestService = (): Promise<TestService> => {
       return Promise.resolve({
         serviceName: 'test-service',
@@ -755,19 +766,19 @@ describe('createLazy', () => {
         }
       });
     };
-    
-    const factory = createLazy(
-      createTestService,
-      { streamData: 'fn:generator' }
-    );
-    
+
+    const factory = createLazy({
+      load: createTestService,
+      properties: { streamData: 'fn:generator' }
+    });
+
     const service = factory();
-    
+
     const values: number[] = [];
     for await (const value of service.streamData()) {
       values.push(value);
     }
-    
+
     assert({
       given: 'generator function is called',
       should: 'yield all values from real service',
@@ -775,28 +786,28 @@ describe('createLazy', () => {
       expected: '1,2,3'
     });
   });
-  
+
   test('generator function returns same instance', async () => {
     interface TestService extends Service {
       streamData: () => AsyncGenerator<number>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         streamData: async function* () {
           yield 1;
           yield 2;
         }
       }),
-      { streamData: 'fn:generator' }
-    );
-    
+      properties: { streamData: 'fn:generator' }
+    });
+
     const service = factory();
-    
+
     const fn1 = service.streamData;
     const fn2 = service.streamData;
-    
+
     assert({
       given: 'generator function property is accessed multiple times',
       should: 'return the same function instance',
@@ -804,46 +815,46 @@ describe('createLazy', () => {
       expected: true
     });
   });
-  
+
   test('generator function calls return different generators', async () => {
     interface TestService extends Service {
       streamData: (prefix: string) => AsyncGenerator<string>;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         streamData: async function* (prefix: string) {
           yield `${prefix}-1`;
           yield `${prefix}-2`;
         }
       }),
-      { streamData: 'fn:generator' }
-    );
-    
+      properties: { streamData: 'fn:generator' }
+    });
+
     const service = factory();
-    
+
     const gen1 = service.streamData('A');
     const gen2 = service.streamData('B');
-    
+
     assert({
       given: 'generator function is called multiple times',
       should: 'return different AsyncGenerator instances',
       actual: gen1 !== gen2,
       expected: true
     });
-    
+
     const values1: string[] = [];
     const values2: string[] = [];
-    
+
     for await (const value of gen1) {
       values1.push(value);
     }
-    
+
     for await (const value of gen2) {
       values2.push(value);
     }
-    
+
     assert({
       given: 'different generator instances with different args',
       should: 'produce independent sequences',
@@ -851,30 +862,110 @@ describe('createLazy', () => {
       expected: 'A-1,A-2|B-1,B-2'
     });
   });
-  
+
   test('void function returns same instance', async () => {
     interface TestService extends Service {
       track: (event: string) => void;
     }
-    
-    const factory = createLazy(
-      () => Promise.resolve({
+
+    const factory = createLazy({
+      load: () => Promise.resolve({
         serviceName: 'test-service',
         track: (event: string) => {}
       }),
-      { track: 'fn:void' }
-    );
-    
+      properties: { track: 'fn:void' }
+    });
+
     const service = factory();
-    
+
     const fn1 = service.track;
     const fn2 = service.track;
-    
+
     assert({
       given: 'void function property is accessed multiple times',
       should: 'return the same function instance',
       actual: fn1 === fn2,
       expected: true
+    });
+  });
+});
+
+// ============================================================================
+// PRELOAD OPTION TESTS
+// ============================================================================
+
+describe('createLazy preload option', () => {
+  interface TestService extends Service {
+    track: (event: string) => void;
+  }
+
+  const makeLoader = (loadCount: { value: number }) => (): Promise<TestService> => {
+    loadCount.value += 1;
+    return Promise.resolve({
+      serviceName: 'test-service',
+      track: (_event: string) => {}
+    });
+  };
+
+  // Stubs requestIdleCallback (absent in the Node test environment) so preload can run.
+  const withIdleCallback = async (run: () => Promise<void>): Promise<void> => {
+    const g = globalThis as { requestIdleCallback?: (callback: () => void) => void };
+    const original = g.requestIdleCallback;
+    g.requestIdleCallback = (callback) => { callback(); };
+    try {
+      await run();
+    } finally {
+      g.requestIdleCallback = original;
+    }
+  };
+
+  test('does not load when preload is not set', async () => {
+    const loadCount = { value: 0 };
+    const factory = createLazy({ load: makeLoader(loadCount), properties: { track: 'fn:void' } });
+
+    factory();
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    assert({
+      given: 'a factory instance created without preload',
+      should: 'not load the real service until a property is touched',
+      actual: loadCount.value,
+      expected: 0
+    });
+  });
+
+  test('preload: true warms the service before any property touch', async () => {
+    await withIdleCallback(async () => {
+      const loadCount = { value: 0 };
+      const factory = createLazy({ load: makeLoader(loadCount), properties: { track: 'fn:void' }, preload: true });
+
+      factory();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      assert({
+        given: 'preload: true with an idle callback available',
+        should: 'load the real service without any property being touched',
+        actual: loadCount.value,
+        expected: 1
+      });
+    });
+  });
+
+  test('preload: true dedupes with the first real property access', async () => {
+    await withIdleCallback(async () => {
+      const loadCount = { value: 0 };
+      const factory = createLazy({ load: makeLoader(loadCount), properties: { track: 'fn:void' }, preload: true });
+
+      const service = factory();
+      service.track('event-1');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      assert({
+        given: 'preload plus a real property touch',
+        should: 'load the real service exactly once',
+        actual: loadCount.value,
+        expected: 1
+      });
     });
   });
 });

--- a/packages/data/src/service/async-data-service/create-lazy.ts
+++ b/packages/data/src/service/async-data-service/create-lazy.ts
@@ -30,12 +30,12 @@ type InferService<F> =
     ? S extends Service ? S : never
     : never;
 
-// Extract Args type from load function  
-type InferArgs<F> = 
-  F extends () => Promise<any> 
-    ? void 
-    : F extends (args: infer A) => Promise<any> 
-      ? A 
+// Extract Args type from load function
+type InferArgs<F> =
+  F extends () => Promise<any>
+    ? void
+    : F extends (args: infer A) => Promise<any>
+      ? A
       : never;
 
 // ============================================================================
@@ -44,47 +44,54 @@ type InferArgs<F> =
 
 /**
  * Creates a lazy-loading wrapper factory for an AsyncDataService.
- * The real service is only loaded when the first property is accessed.
+ * By default the real service is only loaded when the first property is accessed.
  * All calls are queued and executed in order once the service loads.
- * 
- * @param load - Function that loads and returns the real service (may accept args)
- * @param properties - Object describing how to wrap each service property
+ *
+ * @param params - `load` returns the real service (may accept args); `properties` describes how to
+ *   wrap each service property; `preload` (default false) warms the service at browser idle instead
+ *   of waiting for the first property access.
  * @returns A factory function that creates lazy service instances
- * 
+ *
  * TypeScript will enforce:
  * - All service properties must be declared in properties object
  * - Each descriptor must match the actual property type
  * - Clear errors indicate what is missing or wrong
- * 
+ *
  * @example
  * ```typescript
  * // Service with no args
- * const createLazySimple = createLazy(
- *   () => import('./simple').then(m => m.create()),
- *   { data: 'observe', fetch: 'fn:promise' }
- * );
+ * const createLazySimple = createLazy({
+ *   load: () => import('./simple').then(m => m.create()),
+ *   properties: { data: 'observe', fetch: 'fn:promise' }
+ * });
  * const service = createLazySimple();
- * 
- * // Service with args
- * const createLazyConfig = createLazy(
- *   (config: Config) => import('./service').then(m => m.create(config)),
- *   { data: 'observe', fetch: 'fn:promise' }
- * );
+ *
+ * // Service with args, warmed at browser idle
+ * const createLazyConfig = createLazy({
+ *   load: (config: Config) => import('./service').then(m => m.create(config)),
+ *   properties: { data: 'observe', fetch: 'fn:promise' },
+ *   preload: true
+ * });
  * const service = createLazyConfig({ apiUrl: '...' });
  * ```
  */
 export function createLazy<
   LoadFn extends (...args: any[]) => Promise<Service>
 >(
-  load: LoadFn,
-  properties: {
-    [K in Exclude<keyof InferService<LoadFn>, keyof Service>]: 
-      PropertyDescriptor<InferService<LoadFn>[K]>
+  params: {
+    load: LoadFn,
+    properties: {
+      [K in Exclude<keyof InferService<LoadFn>, keyof Service>]:
+        PropertyDescriptor<InferService<LoadFn>[K]>
+    },
+    preload?: boolean
   }
-): InferArgs<LoadFn> extends void 
+): InferArgs<LoadFn> extends void
   ? () => InferService<LoadFn>
   : (args: InferArgs<LoadFn>) => InferService<LoadFn> {
-  
+
+  const { load, properties, preload } = params;
+
   // Return factory function that creates lazy service instances
   return ((...factoryArgs: any[]) => {
     type ServiceType = InferService<LoadFn>;
@@ -108,7 +115,14 @@ export function createLazy<
       
       return loadPromise!;
     };
-    
+
+    // When preload is set, warm the service at browser idle instead of waiting for the first
+    // property touch; ensureLoading memoizes, so it dedupes with that first touch.
+    if (preload) {
+      const idle = (globalThis as { requestIdleCallback?: (callback: () => void) => void }).requestIdleCallback;
+      if (typeof idle === 'function') idle(() => { void ensureLoading(); });
+    }
+
     // Build lazy service object
     const lazyService: any = {
       serviceName: 'lazy-service',

--- a/packages/data/src/service/async-data-service/example.ts
+++ b/packages/data/src/service/async-data-service/example.ts
@@ -52,13 +52,13 @@ type _ValidateUserService = Assert<AsyncDataService.IsValid<UserService>>;
  * Create a lazy-loading wrapper for UserService
  * The real service is only loaded when first accessed
  */
-export const createLazyUserService = AsyncDataService.createLazy(
-  async (): Promise<UserService> => {
+export const createLazyUserService = AsyncDataService.createLazy({
+  load: async (): Promise<UserService> => {
     // In real code, import the actual service implementation
     // e.g., return import('./user-service-impl.js').then(m => m.createUserService())
     throw new Error('Example only - service implementation not provided');
   },
-  {
+  properties: {
     currentUser: 'observe',
     allUsers: 'observe',
     selectUserById: 'fn:observe',
@@ -66,7 +66,7 @@ export const createLazyUserService = AsyncDataService.createLazy(
     updateUser: 'fn:promise',
     clearCache: 'fn:void'
   }
-);
+});
 
 // ============================================================================
 // WITH CONSTRUCTOR ARGS
@@ -88,16 +88,16 @@ type _ValidateConfigurableUserService = Assert<AsyncDataService.IsValid<Configur
 /**
  * Create a lazy-loading wrapper with constructor arguments
  */
-export const createLazyConfigurableUserService = AsyncDataService.createLazy(
-  async (args: UserServiceConfig): Promise<ConfigurableUserService> => {
+export const createLazyConfigurableUserService = AsyncDataService.createLazy({
+  load: async (args: UserServiceConfig): Promise<ConfigurableUserService> => {
     // In real code, import and create the service with args
     // e.g., return import('./configurable-impl.js').then(m => m.createService(args))
     console.log('Service config:', args);
     throw new Error('Example only - service implementation not provided');
   },
-  {
+  properties: {
     config: "observe",
     currentUser: "observe",
     fetchUser: "fn:promise"
   }
-);
+});


### PR DESCRIPTION
## What

`createLazy` now takes a single object argument and gains an optional `preload` flag:

```ts
AsyncDataService.createLazy({
  load,              // () => Promise<Service>  (may take args)
  properties,        // per-property descriptors
  preload?: boolean, // default false
});
```

When `preload: true`, the service is warmed at browser idle via `requestIdleCallback` instead of waiting for the first property access — so the first real `send` / read / call never races a cold load. Defaults to `false`; it is a no-op where `requestIdleCallback` is unavailable (SSR / Node / older browsers), degrading to the existing lazy-on-first-touch behavior.

## Why

A lazy service loads only on first property access. That keeps heavy imports out of the initial bundle, but the first touch pays for the load — and if that touch happens right before the page tears down (e.g. an analytics event fired immediately before a navigation), the load can lose the race and the call is dropped. `preload: true` closes that window without giving up laziness.

## Breaking change

The signature changed from positional `createLazy(load, properties)` to a single object `createLazy({ load, properties, preload? })`. Every existing call site must migrate:

```ts
// before
createLazy(load, { data: 'observe', fetch: 'fn:promise' });

// after
createLazy({ load, properties: { data: 'observe', fetch: 'fn:promise' } });
```

## Tests / docs

- All internal call sites migrated (`create-lazy.test.ts`, `example.ts`); the `@ts-expect-error` type-safety tests are preserved.
- New tests: `preload` unset performs no eager load; `preload: true` warms the service before any property touch and dedupes with the first real access.
- Updated `create-lazy.md` and the `async-data-service` README to the object form.
- `typecheck`, `lint`, and the full data-package suite (2963 tests) pass.

## Also included

A `docs(data)` commit adds a **Corporate contributors** section to the root README documenting how to contribute from a personal GitHub identity (SSH host aliases with `IdentitiesOnly`) when a corporate/EMU account can't fork or push — requested during review.
