### PR TITLE
Fix combined-facets plugin action inference; add BlobRef namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.98",
+    "version": "0.9.99",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.98",
+    "version": "0.9.99",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.98",
+  "version": "0.9.99",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/cache/blob-ref-namespace.type-test.ts
+++ b/packages/data/src/cache/blob-ref-namespace.type-test.ts
@@ -1,0 +1,31 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { BlobRef } from "./blob-store.js";
+import { Schema } from "../schema/index.js";
+import { Nullable } from "../schema/nullable.js";
+import type { Assert } from "../types/assert.js";
+import type { Equal } from "../types/equal.js";
+
+/**
+ * The namespaced `BlobRef` exposes `schema` and `is` under the type's own name,
+ * so consumers reach them without importing the standalone `BlobRefSchema` /
+ * `isBlobRef` — mirroring `BlobHandle` / `BlobMeta`.
+ */
+
+// `BlobRef.schema` is a Schema whose `ToType` is exactly `BlobRef`.
+type _SchemaMatchesType = Assert<Equal<Schema.ToType<typeof BlobRef.schema>, BlobRef>>;
+
+// `BlobRef.is` is the type guard.
+function narrows(value: unknown) {
+    if (BlobRef.is(value)) {
+        const _ok: BlobRef = value;
+    }
+}
+
+// An ECS component that stores a BlobRef has no natural empty value; the honest
+// model is a nullable column with a `null` default — no `as unknown as` cast.
+const imageComponent = { ...Nullable(BlobRef.schema), default: null } as const;
+type _NullableType = Assert<Equal<
+    Schema.ToType<typeof imageComponent>,
+    BlobRef | null
+>>;

--- a/packages/data/src/cache/blob-store.ts
+++ b/packages/data/src/cache/blob-store.ts
@@ -55,6 +55,21 @@ export function isBlobRef(value: unknown): value is BlobRef {
   return isRemoteBlobRef(value) || isLocalBlobRef(value);
 }
 
+/**
+ * Namespaced surface for {@link BlobRef}, mirroring `BlobHandle` / `BlobMeta`
+ * in `../blob/`. Lets consumers reach the schema and guard through the type's
+ * own name — `BlobRef.schema`, `BlobRef.is(x)` — instead of importing the
+ * standalone `BlobRefSchema` / `isBlobRef`. An ECS component that stores a
+ * BlobRef has no natural empty value, so model the column as
+ * `Nullable(BlobRef.schema)` with a `null` default (no cast) rather than a
+ * `null as unknown as BlobRef` placeholder.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace BlobRef {
+  export const schema = BlobRefSchema;
+  export const is = isBlobRef;
+}
+
 function isRemoteUrl(url: string): url is RemoteUrl {
   return url.startsWith(remoteUrlPrefix);
 }

--- a/packages/data/src/cache/index.ts
+++ b/packages/data/src/cache/index.ts
@@ -2,7 +2,7 @@
 
 export {
   type BlobStore,
-  type BlobRef,
+  BlobRef,
   blobStore,
   isBlobRef,
   BlobRefSchema,

--- a/packages/data/src/ecs/database/combined-facets-action-inference.type-test.ts
+++ b/packages/data/src/ecs/database/combined-facets-action-inference.type-test.ts
@@ -1,0 +1,116 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { createPlugin } from "./create-plugin.js";
+import { Database } from "./database.js";
+import type { Observe } from "../../observe/index.js";
+import type { Assert } from "../../types/assert.js";
+import type { Equal } from "../../types/equal.js";
+
+/**
+ * Regression: action inference must survive when `computed` and `actions` are
+ * declared in the SAME `Database.Plugin.create` call.
+ *
+ * The bug: the `computed` factory's `db` type referenced the plugin's OWN
+ * action declarations (`AD`) — the same type parameter being inferred from the
+ * `actions` property. That self-reference made `AD` un-inferable whenever a
+ * sibling `computed` was present in the same call, so it collapsed to `{}` and
+ * every action vanished (`db.actions.x` → TS2339 on `ToActionFunctions<{}>`).
+ * Splitting the facets across layered `create`s hid the bug because each layer
+ * inferred `AD` in isolation.
+ *
+ * The fix: a `computed` factory's `db` surfaces only the BASE plugin's actions
+ * (`XP['actions'] & IP['actions']`), never the same-call `actions`. Those are
+ * declared AFTER `computed` in the enforced property order, so reading one from
+ * a sibling computed was always a forward reference — the action factory `db`
+ * already excludes them for the same reason.
+ */
+
+// ============================================================================
+// 1. POSITIVE — computed + actions in one create; actions stay fully typed.
+// ============================================================================
+
+const combined = createPlugin({
+    components: { count: { type: "number" } },
+    computed: {
+        doubled: (_db): Observe<number> => (() => () => {}),
+    },
+    actions: {
+        bump: (_db, _n: number) => { },
+    },
+});
+
+function combinedActionsAreCallable() {
+    const db = Database.create(combined);
+    db.actions.bump(1); // was TS2339 before the fix
+}
+
+// The declared action survives into the resolved database surface — before the
+// fix this key was absent (the action map collapsed to `{}`).
+type _ActionResolved = Assert<Equal<
+    "bump" extends keyof Database.FromPlugin<typeof combined>["actions"] ? true : false,
+    true
+>>;
+
+// Negative guard: a genuinely-absent action is still rejected.
+function combinedRejectsUnknownAction() {
+    const db = Database.create(combined);
+    // @ts-expect-error — `nope` was never declared.
+    db.actions.nope();
+}
+
+// ============================================================================
+// 2. Layered create (control) — always worked; must keep working.
+// ============================================================================
+
+const base = createPlugin({ components: { count: { type: "number" } } });
+const withComputed = createPlugin({
+    extends: base,
+    computed: { doubled: (_db): Observe<number> => (() => () => {}) },
+});
+const withActions = createPlugin({
+    extends: withComputed,
+    actions: { bump: (_db, _n: number) => { } },
+});
+
+function layeredActionsAreCallable() {
+    const db = Database.create(withActions);
+    db.actions.bump(1);
+}
+
+// ============================================================================
+// 3. Semantics — a computed sees BASE actions but not same-create siblings.
+// ============================================================================
+
+const actionBase = createPlugin({
+    components: { count: { type: "number" } },
+    actions: { baseAct: (_db) => { } },
+});
+
+createPlugin({
+    extends: actionBase,
+    computed: {
+        // A computed CAN compose on a base plugin's already-resolved action.
+        readsBaseAction: (db): Observe<unknown> => {
+            db.actions.baseAct();
+            return (() => () => {});
+        },
+    },
+    actions: {
+        siblingAct: (_db) => { },
+    },
+});
+
+createPlugin({
+    components: { count: { type: "number" } },
+    computed: {
+        noSiblingActions: (db): Observe<unknown> => {
+            // @ts-expect-error — a same-create sibling action is a forward
+            // reference (actions are declared after computed) and must be absent.
+            db.actions.siblingAct2();
+            return (() => () => {});
+        },
+    },
+    actions: {
+        siblingAct2: (_db) => { },
+    },
+});

--- a/packages/data/src/ecs/database/computed-factory-services.type-test.ts
+++ b/packages/data/src/ecs/database/computed-factory-services.type-test.ts
@@ -1,0 +1,127 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { createPlugin } from "./create-plugin.js";
+import { Database } from "./database.js";
+import type { Observe } from "../../observe/index.js";
+import type { Assert } from "../../types/assert.js";
+import type { Equal } from "../../types/equal.js";
+
+/**
+ * A declared service must keep its full type when read from a `computed`
+ * factory's `db.services.<name>`.
+ *
+ * This was reported as lost — a `computed` factory reading a service off the
+ * extended chain saw it as `unknown`, forcing a cast at the boundary. On the
+ * current type surface the service type is threaded correctly (the
+ * computed-factory `db` is built by `FullDBForPlugin`, whose service slot is
+ * `FromServiceFactories<RemoveIndex<SVF> & XP['services']>`), so these positive
+ * checks hold. This file pins that behavior so the loss cannot silently return.
+ *
+ * The check is exercised across every shape that reported the loss: the service
+ * on an `extends` base, on a combined base, declared locally in the same call,
+ * and imported — including the case where the service factory itself reads a
+ * further chain service. The asymmetry originally cited (a `systems` `create`
+ * body and the fully-resolved `Database.FromPlugin<...>['services']` typed the
+ * same service correctly) is pinned too.
+ */
+
+type Thing = { readonly id: number };
+type HostThing = { readonly hostId: number };
+
+const servicePlugin = createPlugin({
+    services: {
+        imageCompositor: (_db): Observe<Thing | null> => (() => () => {}),
+    },
+});
+
+// 1. Service on an `extends` base — read from a computed factory.
+createPlugin({
+    extends: servicePlugin,
+    computed: {
+        probe: (db): Observe<unknown> => {
+            type Svc = typeof db.services.imageCompositor;
+            type _Ok = Assert<Equal<Svc, Observe<Thing | null>>>;
+            // Negative guard: a service that was never declared is absent.
+            // @ts-expect-error — `missing` is not a declared service.
+            db.services.missing;
+            return (() => () => {});
+        },
+    },
+});
+
+// 2. Service declared LOCALLY in the same create as the computed.
+createPlugin({
+    services: {
+        imageCompositor: (_db): Observe<Thing | null> => (() => () => {}),
+    },
+    computed: {
+        probe: (db): Observe<unknown> => {
+            type Svc = typeof db.services.imageCompositor;
+            type _Ok = Assert<Equal<Svc, Observe<Thing | null>>>;
+            return (() => () => {});
+        },
+    },
+});
+
+// 3. Service via `imports`.
+createPlugin({
+    imports: servicePlugin,
+    computed: {
+        probe: (db): Observe<unknown> => {
+            type Svc = typeof db.services.imageCompositor;
+            type _Ok = Assert<Equal<Svc, Observe<Thing | null>>>;
+            return (() => () => {});
+        },
+    },
+});
+
+// 4. Faithful multi-layer chain: a service on a plugin that `extends` a
+//    `combine`, whose factory reads a further chain service; the type must
+//    still survive one layer down in a computed.
+const hostPlugin = createPlugin({
+    services: {
+        host: (_db): HostThing => { throw new Error("inject"); },
+    },
+});
+const scenePlugin = createPlugin({
+    components: { sceneName: { type: "string" } },
+});
+const servicesPlugin = createPlugin({
+    extends: Database.Plugin.combine(scenePlugin, hostPlugin),
+    services: {
+        imageCompositor: (db): Observe<Thing | null> => {
+            const _h: HostThing = db.services.host; // reads a chain service
+            return (() => () => {});
+        },
+    },
+});
+createPlugin({
+    extends: servicesPlugin,
+    computed: {
+        status: (db): Observe<unknown> => {
+            type Svc = typeof db.services.imageCompositor;
+            type _Ok = Assert<Equal<Svc, Observe<Thing | null>>>;
+            return (() => () => {});
+        },
+    },
+});
+
+// 5. Asymmetry pins — the same service typed correctly on a `systems` create
+//    body and on the fully-resolved FromPlugin services surface.
+createPlugin({
+    extends: servicePlugin,
+    systems: {
+        probeSys: {
+            create: (db) => {
+                type Svc = typeof db.services.imageCompositor;
+                type _Ok = Assert<Equal<Svc, Observe<Thing | null>>>;
+                return () => { };
+            },
+        },
+    },
+});
+
+type _FromPluginServices = Assert<Equal<
+    Database.FromPlugin<typeof servicePlugin>["services"]["imageCompositor"],
+    Observe<Thing | null>
+>>;

--- a/packages/data/src/ecs/database/create-plugin.ts
+++ b/packages/data/src/ecs/database/create-plugin.ts
@@ -194,7 +194,15 @@ export function createPlugin<
     const AD,
     const S extends string = never,
     const SVF extends ServiceFactories<Database.FromPlugin<AmbientPlugin<XP, IP>>> = {},
-    const CVF extends PluginComputedFactories<FullDBForPlugin<RemoveIndex<CS>, RemoveIndex<RS>, RemoveIndex<A>, RemoveIndex<TD>, S, RemoveIndex<AD> & XP['actions'] & IP['actions'], AmbientPlugin<XP, IP>, RemoveIndex<SVF>, RemoveIndex<IX>>> = {},
+    // The computed-factory `db` surfaces only the BASE plugins' actions
+    // (`XP['actions'] & IP['actions']`), never this call's own `AD`. `AD` is
+    // inferred from the sibling `actions` property, so referencing it in the
+    // `computed` contextual type made `AD` un-inferable whenever both facets
+    // shared one `create` — it collapsed to `{}` and every action vanished.
+    // Excluding it is also correct semantically: `actions` are declared after
+    // `computed`, so a computed reading a same-call action is a forward
+    // reference — the action factory `db` already omits `AD` for the same reason.
+    const CVF extends PluginComputedFactories<FullDBForPlugin<RemoveIndex<CS>, RemoveIndex<RS>, RemoveIndex<A>, RemoveIndex<TD>, S, XP['actions'] & IP['actions'], AmbientPlugin<XP, IP>, RemoveIndex<SVF>, RemoveIndex<IX>>> = {},
 >(
     plugins: {
         imports?: IP,
@@ -206,7 +214,7 @@ export function createPlugin<
         resources?: RS,
         archetypes?: A,
         indexes?: IX,
-        computed?: CVF & PluginComputedFactories<FullDBForPlugin<RemoveIndex<CS>, RemoveIndex<RS>, RemoveIndex<A>, {}, string, RemoveIndex<AD> & XP['actions'] & IP['actions'], AmbientPlugin<XP, IP>, RemoveIndex<SVF>, RemoveIndex<IX>>>,
+        computed?: CVF & PluginComputedFactories<FullDBForPlugin<RemoveIndex<CS>, RemoveIndex<RS>, RemoveIndex<A>, {}, string, XP['actions'] & IP['actions'], AmbientPlugin<XP, IP>, RemoveIndex<SVF>, RemoveIndex<IX>>>,
         transactions?: TD,
         actions?: AD & {
             readonly [K: string]: (db: Database<


### PR DESCRIPTION
## Summary

Two plugin type-inference fixes plus a `BlobRef` ergonomics addition, each backed by compile-time type tests. All additive/non-breaking. Version bumped 0.9.98 → 0.9.99.

### 1. Fix: combined-facets action inference collapse
`Database.Plugin.create({ components, computed, actions })` in a single call collapsed `db.actions` to `ToActionFunctions<{}>` (TS2339 on every action), forcing consumers to split every plugin into one-facet-per-`create` layers.

**Root cause:** in `create-plugin.ts`, the computed-factory `db` built its `actions` slot from the *local* `AD` type param (inferred from the sibling `actions` property). Referencing `AD` in the `computed` contextual type made it un-inferable whenever a computed shared the call, so it fell back to `{}`. The action-factory `db` already excluded local `AD` — that asymmetry was the bug. It's also a forward reference (actions are declared after computed in the enforced order; a computed reading a same-call action never actually worked).

**Fix:** drop local `AD` from both computed-`db` sites (`XP['actions'] & IP['actions']` only). No `as` casts.

**Red test:** `combined-facets-action-inference.type-test.ts` — positive `Assert<Equal>`, `@ts-expect-error` negatives, a layered-create control, and semantics guards (a computed CAN read a *base* action; a same-create sibling action is correctly absent). Confirmed genuinely red without the fix, green with it, across TS 5.8.3 / 6.0.2 / tsgo 7.0.2.

### 2. Regression guard: services thread to the computed-factory boundary
`computed-factory-services.type-test.ts` pins that `db.services.X` is correctly typed inside a computed factory (already true via `FullDBForPlugin`; this locks it against regression, and documents that a consumer manufacturing `unknown` via a hand-typed param is unnecessary).

### 3. `BlobRef` namespace
Merged a namespaced `BlobRef` (`export namespace BlobRef { schema = BlobRefSchema; is = isBlobRef }`) mirroring `BlobHandle`, re-exported from `cache/index.ts`. Consumers can write `BlobRef.schema` / `BlobRef.is` instead of the standalone symbols. Standalone `BlobRefSchema`/`isBlobRef` kept. An ECS component storing a BlobRef should use `{ ...Nullable(BlobRef.schema), default: null }` (no cast) — proven in `blob-ref-namespace.type-test.ts`.

## Verification
- `packages/data` typecheck (build-assembly + tsc -b): clean. Lint: clean.
- Node test suite: 1466 pass (pre-existing `assembly.test.ts` needs the WASM build, unrelated).
- No public-type weakening: all consumer samples (`data-lit`, `data-lit-todo`, `data-lit-tictactoe`, `data-lit-space-rock-game`, `data-persistence`, `data-sync`) rebuild clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)