### PR TITLE
feat(data-testing): uniform conformance envelope + portable case types (0.9.103)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-hopper/src/features/main/data/state/conformance-case.ts
+++ b/packages/data-gpu-hopper/src/features/main/data/state/conformance-case.ts
@@ -4,9 +4,7 @@ import type { State } from "./state.js";
 
 // The per-feature conformance surface — the shared `@adobe/data-testing` machinery
 // with `State` bound once. `Conformance.cases(fn, [options,] ...cases)` declares a
-// transform's cases (the case types come from `fn`); a derivation authors
-// `Derivation<typeof fn>`. This tiny file is the only per-feature conformance
+// transform's cases (the case types come from `fn`); `Conformance.derivations(fn, ...cases)`
+// a derivation's. This tiny file is the only per-feature conformance
 // declaration; everything else lives in `@adobe/data-testing`.
-export const Conformance = { cases: ConformanceApi.casesBuilder<State>() };
-export type Derivation<F extends (...args: never[]) => unknown> =
-  ConformanceApi.DerivationCases<F>;
+export const Conformance = { cases: ConformanceApi.casesBuilder<State>(), derivations: ConformanceApi.derivationsBuilder() };

--- a/packages/data-gpu-hopper/src/features/main/services/main-service/system-database/tick-loop.test.ts
+++ b/packages/data-gpu-hopper/src/features/main/services/main-service/system-database/tick-loop.test.ts
@@ -27,7 +27,7 @@ import { projection } from "../conformance/projection.js";
 import { driveFrame } from "../conformance/drive-frame.js";
 
 describe("ECS system tick loop conforms to State.step (one frame = one step)", () => {
-  for (const testCase of cases) {
+  for (const testCase of cases.cases) {
     it(testCase.name, () => {
       const dt = testCase.args;
       // A case `before` is a delta over the feature default and `after` a writes

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-space-rock-game/src/features/main/data/state/conformance-case.ts
+++ b/packages/data-lit-space-rock-game/src/features/main/data/state/conformance-case.ts
@@ -4,9 +4,7 @@ import type { State } from "./state.js";
 
 // The per-feature conformance surface — the shared `@adobe/data-testing` machinery
 // with `State` bound once. `Conformance.cases(fn, [options,] ...cases)` declares a
-// transform's cases (the case types come from `fn`); a derivation authors
-// `Derivation<typeof fn>`. This tiny file is the only per-feature conformance
+// transform's cases (the case types come from `fn`); `Conformance.derivations(fn, ...cases)`
+// a derivation's. This tiny file is the only per-feature conformance
 // declaration; everything else lives in `@adobe/data-testing`.
-export const Conformance = { cases: ConformanceApi.casesBuilder<State>() };
-export type Derivation<F extends (...args: never[]) => unknown> =
-  ConformanceApi.DerivationCases<F>;
+export const Conformance = { cases: ConformanceApi.casesBuilder<State>(), derivations: ConformanceApi.derivationsBuilder() };

--- a/packages/data-lit-space-rock-game/src/features/main/services/main-service/system-database/tick-loop.test.ts
+++ b/packages/data-lit-space-rock-game/src/features/main/services/main-service/system-database/tick-loop.test.ts
@@ -33,7 +33,7 @@ import { projection } from "../conformance/projection.js";
 import { driveFrame } from "../conformance/drive-frame.js";
 
 describe("ECS system tick loop conforms to State.step (one frame = one step)", () => {
-  for (const testCase of cases) {
+  for (const testCase of cases.cases) {
     it(testCase.name, () => {
       const { dt, input } = testCase.args;
       // A case `before` is a delta over the feature default (`Case.before` is

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/src/features/main/data/state/conformance-case.ts
+++ b/packages/data-lit-tictactoe/src/features/main/data/state/conformance-case.ts
@@ -4,10 +4,8 @@ import type { State } from "./state.js";
 
 // The per-feature conformance surface — the shared `@adobe/data-testing` machinery
 // with `State` bound once. `Conformance.cases(fn, [options,] ...cases)` declares a
-// transform's cases (the case types come from `fn`); a derivation authors
-// `Derivation<typeof fn>`. This tiny file is the only per-feature conformance
+// transform's cases (the case types come from `fn`); `Conformance.derivations(fn, ...cases)`
+// a derivation's. This tiny file is the only per-feature conformance
 // declaration; everything else lives in `@adobe/data-testing`.
-export const Conformance = { cases: ConformanceApi.casesBuilder<State>() };
-export type Derivation<F extends (...args: never[]) => unknown> =
-  ConformanceApi.DerivationCases<F>;
+export const Conformance = { cases: ConformanceApi.casesBuilder<State>(), derivations: ConformanceApi.derivationsBuilder() };
 export type Effects<Args> = ConformanceApi.Effects<Args>;

--- a/packages/data-lit-tictactoe/src/features/main/data/state/current-player.ts
+++ b/packages/data-lit-tictactoe/src/features/main/data/state/current-player.ts
@@ -2,7 +2,7 @@
 import { BoardState } from "../board-state/board-state.js";
 import type { PlayerMark } from "../player-mark/player-mark.js";
 import type { State } from "./state.js";
-import type { Derivation } from "./conformance-case.js";
+import { Conformance } from "./conformance-case.js";
 
 // Whose turn it is: composes TWO `State` fields — the board (move count) and the
 // `firstPlayer` — so it is a `state/` derivation, not single-field board math
@@ -15,7 +15,7 @@ export const currentPlayer = (
 
 // Spec-owned cases, shared with the ecs `currentPlayer` computed. A derivation
 // case is `{ input, value }`; `input` is a full `State`, `value` the mark to move.
-export const cases: Derivation<typeof currentPlayer> = [
+export const cases = Conformance.derivations(currentPlayer,
   {
     name: "the first player moves on an empty board",
     input: {
@@ -48,4 +48,4 @@ export const cases: Derivation<typeof currentPlayer> = [
     },
     value: "X",
   },
-];
+);

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/src/features/main/data/state/conformance-case.ts
+++ b/packages/data-lit-todo/src/features/main/data/state/conformance-case.ts
@@ -4,10 +4,8 @@ import type { State } from "./state.js";
 
 // The per-feature conformance surface — the shared `@adobe/data-testing` machinery
 // with `State` bound once. `Conformance.cases(fn, [options,] ...cases)` declares a
-// transform's cases (the case types come from `fn`); a derivation authors
-// `Derivation<typeof fn>`. This tiny file is the only per-feature conformance
+// transform's cases (the case types come from `fn`); `Conformance.derivations(fn, ...cases)`
+// a derivation's. This tiny file is the only per-feature conformance
 // declaration; everything else lives in `@adobe/data-testing`.
-export const Conformance = { cases: ConformanceApi.casesBuilder<State>() };
-export type Derivation<F extends (...args: never[]) => unknown> =
-  ConformanceApi.DerivationCases<F>;
+export const Conformance = { cases: ConformanceApi.casesBuilder<State>(), derivations: ConformanceApi.derivationsBuilder() };
 export type Effects<Args> = ConformanceApi.Effects<Args>;

--- a/packages/data-lit-todo/src/features/main/data/state/visible-todos.ts
+++ b/packages/data-lit-todo/src/features/main/data/state/visible-todos.ts
@@ -1,7 +1,7 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 import type { State } from "./state.js";
 import type { Todo } from "../todo/todo.js";
-import type { Derivation } from "./conformance-case.js";
+import { Conformance } from "./conformance-case.js";
 // The todos the user should see, in display order (ascending `order`): all of them
 // when `displayCompleted`, otherwise only the incomplete ones. Yields id-less
 // values — identity is the `entities` key, so the visible list compares by content.
@@ -16,7 +16,7 @@ export const visibleTodos = (
 // computed the runner hydrates through `toData` into these id-less values). A
 // derivation case is `{ input, value }`; `input` is keyed by PLAIN spec-ids;
 // `value` is id-less content in significant display order.
-export const cases: Derivation<typeof visibleTodos> = [
+export const cases = Conformance.derivations(visibleTodos,
   {
     name: "hides completed todos unless the completed view is on",
     input: {
@@ -46,4 +46,4 @@ export const cases: Derivation<typeof visibleTodos> = [
       { name: "b", complete: true, order: 1 },
     ],
   },
-];
+);

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.9.102",
+    "version": "0.9.103",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/src/features/main/data/state/conformance-case.ts
+++ b/packages/data-react-pixie/src/features/main/data/state/conformance-case.ts
@@ -4,9 +4,7 @@ import type { State } from "./state.js";
 
 // The per-feature conformance surface — the shared `@adobe/data-testing` machinery
 // with `State` bound once. `Conformance.cases(fn, [options,] ...cases)` declares a
-// transform's cases (the case types come from `fn`); a derivation authors
-// `Derivation<typeof fn>`. This tiny file is the only per-feature conformance
+// transform's cases (the case types come from `fn`); `Conformance.derivations(fn, ...cases)`
+// a derivation's. This tiny file is the only per-feature conformance
 // declaration; everything else lives in `@adobe/data-testing`.
-export const Conformance = { cases: ConformanceApi.casesBuilder<State>() };
-export type Derivation<F extends (...args: never[]) => unknown> =
-  ConformanceApi.DerivationCases<F>;
+export const Conformance = { cases: ConformanceApi.casesBuilder<State>(), derivations: ConformanceApi.derivationsBuilder() };

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.9.102",
+    "version": "0.9.103",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data-testing/src/conformance/cases.ts
+++ b/packages/data-testing/src/conformance/cases.ts
@@ -1,6 +1,6 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 import type { Schema } from "@adobe/data/schema";
-import type { Case } from "./types.js";
+import type { Case, DerivationCase } from "./types.js";
 
 type AnyFn = (...args: never[]) => unknown;
 // The transition's args type — its second parameter, or `void` when it takes none.
@@ -33,41 +33,61 @@ type CasesOptions<F extends AnyFn, S extends Schema> = {
   readonly args?: S & (ArgsOf<F> extends Schema.ToType<S> ? unknown : ArgsSchemaMismatch);
 };
 
-// The value a transition's `cases` export holds when options are given — the schema
-// travels with the case list so discovery reads both.
-export type CasesWithOptions<State, F extends AnyFn> = {
+// The single envelope EVERY `cases` export holds — always an object, never a bare
+// array, whether or not an `args` schema was given. One shape means discovery and the
+// runners read `.cases` / `.args` with no branch, and there is exactly one way to
+// author cases (a bare `cases = [ … ]` array is no longer a valid export).
+export type CasesResult<State, F extends AnyFn> = {
   readonly args?: Schema;
   readonly cases: readonly Case<State, ArgsOf<F>>[];
+};
+
+// The same envelope for a derivation's `{ input, value }` cases (never any `args`).
+export type DerivationsResult<F extends AnyFn> = {
+  readonly cases: readonly DerivationCase<Parameters<F>[0], ReturnType<F>>[];
 };
 
 // The `State`-bound cases builder a feature aliases (`Conformance.cases`). `fn` is
 // passed for TYPING only (so both the case types and the `args`-schema pin infer);
 // discovery pairs the ecs op by the function's own name, so the builder ignores
-// `fn` at runtime. The cases use a `const` type parameter `C` so their literals keep
-// their narrow types — a `Vec2` tuple stays `readonly [number, number]` rather than
-// widening to `number[]` — while `C`'s constraint still checks each case's shape.
+// `fn` at runtime. Both overloads emit the SAME `CasesResult` envelope.
 export interface CasesBuilder<State> {
   // No-options overload FIRST: a `cases(fn, ...cases)` call matches here immediately,
   // so the case literals keep their contextual types (a `Vec2` tuple stays a tuple).
   // `NoInfer` pins `F` to `fn`, not the cases.
-  <F extends AnyFn>(fn: F, ...cases: readonly Case<State, ArgsOf<NoInfer<F>>>[]): readonly Case<State, ArgsOf<NoInfer<F>>>[];
+  <F extends AnyFn>(fn: F, ...cases: readonly Case<State, ArgsOf<NoInfer<F>>>[]): CasesResult<State, F>;
   // Options overload SECOND: reached only when the second arg is an options object
   // (a `Case` has a `name`, which the options type forbids, so it can't match here).
   <F extends AnyFn, const S extends Schema = Schema>(
     fn: F,
     options: CasesOptions<F, S>,
     ...cases: readonly Case<State, ArgsOf<NoInfer<F>>>[]
-  ): CasesWithOptions<State, F>;
+  ): CasesResult<State, F>;
+}
+
+// The derivation builder a feature aliases (`Conformance.derivations`) — emits the
+// same `{ cases }` envelope so discovery reads one shape for transitions and
+// derivations alike (it dispatches on case shape, not export shape).
+export interface DerivationsBuilder {
+  <F extends AnyFn>(
+    fn: F,
+    ...cases: readonly DerivationCase<Parameters<NoInfer<F>>[0], ReturnType<NoInfer<F>>>[]
+  ): DerivationsResult<F>;
 }
 
 export const casesBuilder = <State>(): CasesBuilder<State> => {
   const build = (_fn: AnyFn, ...rest: readonly unknown[]): unknown => {
     const first = rest[0];
     // An options object has no `name` (every case does), so it discriminates the
-    // two overloads at runtime.
+    // two overloads at runtime; either way the result is one `{ args?, cases }` shape.
     const isOptions =
       first !== null && typeof first === "object" && !Array.isArray(first) && !("name" in first);
-    return isOptions ? { ...(first as object), cases: rest.slice(1) } : rest;
+    return isOptions ? { ...(first as object), cases: rest.slice(1) } : { cases: rest };
   };
   return build as CasesBuilder<State>;
+};
+
+export const derivationsBuilder = (): DerivationsBuilder => {
+  const build = (_fn: AnyFn, ...cases: readonly unknown[]): unknown => ({ cases });
+  return build as DerivationsBuilder;
 };

--- a/packages/data-testing/src/conformance/cases.type-test.ts
+++ b/packages/data-testing/src/conformance/cases.type-test.ts
@@ -1,10 +1,11 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
-// Type-level checks for the `cases` builder's args-schema pin.
+// Type-level checks for the `cases` builder's args-schema pin and its uniform envelope.
 import { Entity } from "@adobe/data/ecs";
-import { casesBuilder } from "./cases.js";
+import { casesBuilder, derivationsBuilder } from "./cases.js";
 
 type State = { readonly entities: ReadonlyMap<number, { readonly name: string }>; readonly selected: number };
 const cases = casesBuilder<State>();
+const derivations = derivationsBuilder();
 
 const reparent = (_s: Pick<State, "selected">, args: { readonly id: number; readonly count: number }): Pick<State, "selected"> => ({
   selected: args.id,
@@ -19,12 +20,18 @@ export const good = cases(
   { args: { type: "object", properties: { id: Entity.schema, count: { type: "integer" } } } },
   { name: "ok", before: {}, args: { id: 1, count: 2 }, after: { selected: 1 } },
 );
-// Options form carries the schema on the value.
+// Both forms emit the SAME envelope `{ args?, cases }` — never a bare array.
+const _hasArgs: (typeof good)["args"] = good.args;
 const _hasCases: (typeof good)["cases"] = good.cases;
 
-// The no-args overload returns a bare array.
-export const noArgsCases = cases(noArgs, { name: "n", before: {}, after: { selected: 0 } });
-const _isArray: readonly unknown[] = noArgsCases;
+// The no-args overload emits the same envelope (no bare array).
+export const noArgsResult = cases(noArgs, { name: "n", before: {}, after: { selected: 0 } });
+const _noArgsCases: readonly unknown[] = noArgsResult.cases;
+
+// A derivation emits `{ cases }` through the parallel builder.
+const derive = (_s: State): number => _s.selected;
+export const derived = derivations(derive, { name: "d", input: { entities: new Map(), selected: 0 }, value: 0 });
+const _derivedCases: readonly unknown[] = derived.cases;
 
 // A schema that DIVERGES from the signature (id typed as string) must be rejected:
 // `Schema.ToType<args>.id` is `string`, but the transition's `args.id` is `number`.

--- a/packages/data-testing/src/conformance/discover.ts
+++ b/packages/data-testing/src/conformance/discover.ts
@@ -9,10 +9,9 @@ export interface Discovered {
   readonly argsSchema?: Schema;
 }
 
-// A `cases` export is either a plain array (no args schema) or the builder's
-// options form `{ args, cases }`. Normalize to a `{ list, argsSchema }` pair.
+// Every `cases` export is the builder envelope `{ args?, cases }` (a bare array is no
+// longer valid). Read the list and optional schema off it — one shape, no branch.
 const normalizeCases = (raw: unknown): { list: readonly unknown[]; argsSchema?: Schema } => {
-  if (Array.isArray(raw)) return { list: raw };
   if (raw !== null && typeof raw === "object" && Array.isArray((raw as { cases?: unknown }).cases)) {
     const { cases, args } = raw as { cases: readonly unknown[]; args?: Schema };
     return { list: cases, argsSchema: args };

--- a/packages/data-testing/src/conformance/public.ts
+++ b/packages/data-testing/src/conformance/public.ts
@@ -1,6 +1,13 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 export type { Case, Cases, DerivationCase, DerivationCases, Effects, ServiceCall } from "./types.js";
-export { casesBuilder, type CasesBuilder, type CasesWithOptions } from "./cases.js";
+export {
+  casesBuilder,
+  derivationsBuilder,
+  type CasesBuilder,
+  type CasesResult,
+  type DerivationsBuilder,
+  type DerivationsResult,
+} from "./cases.js";
 export { runSpec, type SpecRunConfig } from "./run-spec.js";
 export { runTransactions, type TransactionRunConfig } from "./run-transactions.js";
 export { runActions, type ActionRunConfig } from "./run-actions.js";

--- a/packages/data-testing/src/conformance/run-spec.empty-cases.test.ts
+++ b/packages/data-testing/src/conformance/run-spec.empty-cases.test.ts
@@ -1,14 +1,15 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 import { Conformance } from "../index.js";
 
-// Module with `cases: []` opens an empty `describe` and used to leave the file
-// suite-less. Empty discovery registers a no-op so Vitest still collects a suite.
+// A module whose envelope holds `cases: []` opens an empty `describe` and used to
+// leave the file suite-less. Empty discovery registers a no-op so Vitest still
+// collects a suite.
 Conformance.runSpec({
   state: { create: () => ({ n: 0 }) },
   transitions: {
     "./empty-cases.ts": {
       noop: (state: { n: number }) => state,
-      cases: [],
+      cases: { cases: [] },
     },
   },
 });

--- a/packages/data-testing/src/conformance/run-spec.test.ts
+++ b/packages/data-testing/src/conformance/run-spec.test.ts
@@ -13,20 +13,24 @@ Conformance.runSpec({
   transitions: {
     "./increment.ts": {
       increment,
-      cases: [
-        {
-          name: "adds the delta over State.create()",
-          before: {},
-          args: { by: 2 },
-          after: { n: 2 },
-        },
-        {
-          name: "honors a non-default before delta",
-          before: { n: 10 },
-          args: { by: 1 },
-          after: { n: 11 },
-        },
-      ],
+      // A module's `cases` export is the builder envelope `{ cases }` (bare arrays are
+      // no longer valid); build it directly so run-spec reads the same shape.
+      cases: {
+        cases: [
+          {
+            name: "adds the delta over State.create()",
+            before: {},
+            args: { by: 2 },
+            after: { n: 2 },
+          },
+          {
+            name: "honors a non-default before delta",
+            before: { n: 10 },
+            args: { by: 1 },
+            after: { n: 11 },
+          },
+        ],
+      },
     },
   },
 });

--- a/packages/data-testing/src/conformance/run-spec.ts
+++ b/packages/data-testing/src/conformance/run-spec.ts
@@ -84,10 +84,9 @@ export const runSpec = (config: SpecRunConfig): void => {
       suites.push({ kind: "invalid", path, label, exportNames });
       continue;
     }
-    // `cases` is either a plain array or the builder's `{ args, cases }` options
-    // form; the pure side ignores the `args` schema (spec-ids need no resolution).
-    const rawCases = module["cases"];
-    const cases = Array.isArray(rawCases) ? rawCases : ((rawCases as { cases?: readonly unknown[] })?.cases ?? []);
+    // `cases` is the builder envelope `{ args?, cases }`; the pure side ignores the
+    // `args` schema (spec-ids need no resolution) and reads the list.
+    const cases = (module["cases"] as { cases?: readonly unknown[] })?.cases ?? [];
     // Empty `cases: []` is not a suite (and would open a Vitest describe with no
     // tests, which fails even when this file has other suites).
     if (cases.length === 0) continue;

--- a/packages/data-testing/src/index.ts
+++ b/packages/data-testing/src/index.ts
@@ -7,3 +7,19 @@
 // Import only from `*.test.ts`; `sideEffects: false` keeps it out of app builds.
 export * as Match from "./match/public.js";
 export * as Conformance from "./conformance/public.js";
+
+// The conformance case TYPES, also re-exported top-level (compile-time only, so the
+// `Conformance` namespace API is unchanged). A `Conformance.cases(...)` result flows
+// into a downstream package's emitted `.d.ts` as one of these types; TS cannot name a
+// type reached only through an `export * as` namespace, so without a top-level path it
+// falls back to the deep `dist/…` file path — which is not a package export, and the
+// consumer's build fails with TS2883. Naming them here makes that reference portable.
+export type {
+  Case,
+  Cases,
+  CasesWithOptions,
+  DerivationCase,
+  DerivationCases,
+  Effects,
+  ServiceCall,
+} from "./conformance/public.js";

--- a/packages/data-testing/src/index.ts
+++ b/packages/data-testing/src/index.ts
@@ -17,9 +17,10 @@ export * as Conformance from "./conformance/public.js";
 export type {
   Case,
   Cases,
-  CasesWithOptions,
+  CasesResult,
   DerivationCase,
   DerivationCases,
+  DerivationsResult,
   Effects,
   ServiceCall,
 } from "./conformance/public.js";

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.9.102",
+  "version": "0.9.103",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## What

Follow-up to #175. Two changes that make `Conformance.cases` / `Conformance.derivations` clean to author in an external consumer that emits declarations:

### 1. One uniform output envelope

The builders previously emitted **two output shapes** — a bare `Case[]` from `cases(fn, ...cases)` vs. `{ args, cases }` when an options object was passed — so discovery had to `Array.isArray`-branch and each consumer's local `Cases<F>` alias was a union of `Cases | CasesWithOptions`.

Now **both call forms emit one shape**:

- `Conformance.cases(fn, [{ args },] ...cases)` → `CasesResult<State, F>` = `{ readonly args?: Schema; readonly cases: Case[] }`
- `Conformance.derivations(fn, ...cases)` → `DerivationsResult<F>` = `{ readonly cases: DerivationCase[] }`

The call still accepts two argument forms (with/without the leading options object) — the impl distinguishes an options object from a case by shape — but the **return is always the envelope**. Discovery (`discover.ts`, `run-spec.ts`) reads `.cases` / `.args` with no `Array.isArray`. Bare-array `cases` exports are no longer discovered (the one pattern is the builder).

### 2. Portable top-level case types

`Case` / `CasesResult` / `DerivationCase(s)` / `Effects` reached the package root only through `export * as Conformance`. TypeScript **cannot name a type reached through an `export * as` namespace** in emitted `.d.ts`, so a consumer writing `export const cases = Conformance.cases(fn, …)` fell back to a deep, non-portable `dist/conformance/*.js` path (**TS2883**) and had to hand-annotate every `cases` export. Re-exporting the case **types** top-level (alongside the unchanged `Conformance` namespace) lets the consumer's `.d.ts` name them via the portable bare specifier — annotation gone.

## Result — extra typing removed in both repos

- **data samples**: already annotation-free; the local `Cases<F>` alias collapses from a two-member union to the single `CasesResult<State, F>`. Derivations move to `Conformance.derivations`; tick-loop tests iterate `cases.cases`.
- **Firefly Platform** (first external consumer): scene-graph + smooth-talk `data/state/*.ts` compile with **zero** `Cases<typeof fn>` annotations and **zero TS2883** against this build (studio + `src/features` both 0 errors).

## Verification
- `data-testing`: lint ✓, `tsc -b` ✓, 18 tests ✓
- Full monorepo: lint ✓, build ✓, all sample suites ✓ (todo 106, tictactoe 99, pixie 42, gpu-hopper 90, space-rock 135)
- FFP studio + `src/features` typecheck ✓ annotation-free against this dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)