### PR TITLE
feat(data): count / observe.count — allocation-free entity counting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/.claude/rules/ecs.md
+++ b/packages/data-ai/.claude/rules/ecs.md
@@ -140,6 +140,9 @@ Synchronous, deterministic atomic mutations. Receive `store` and a payload.
 - `store.resources.x = value` — mutate resources
 - `store.get(entity, 'component')` — read component value
 - `store.select(archetype.components, { where })` — query entities
+- `store.count(archetype.components, { where })` — count entities; sums archetype row
+  counts with no entity-array allocation (reactive: `db.observe.count(...)` →
+  `Observe<number>`). Prefer over `select(...).length` for membership/count computeds.
 
 ### actions
 

--- a/packages/data-ai/.claude/rules/features/services/main-service/computed.md
+++ b/packages/data-ai/.claude/rules/features/services/main-service/computed.md
@@ -46,6 +46,12 @@ Type the parameter on the lowest database layer that exposes what it
 reads. An `index.ts` barrel re-exports every computed; `computed-database.ts`
 registers it under the `computed` facet.
 
+For a computed that only needs *how many* entities match an archetype (an
+empty-state flag, a badge count), read `db.observe.count(archetype.components,
+{ where })` — an `Observe<number>` that sums archetype row counts and re-emits
+only when the count changes, allocating no entity array. Prefer it over
+`db.observe.select(...)` mapped through `.length`.
+
 **Conform a computed to its `data/state` derivation** whenever one exists. The
 derivation co-locates `{ input, value }` cases (`Derivation<typeof fn>`), and the
 feature's single `conformance/conformance.test.ts` `Conformance.runFeature({...})`

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -165,6 +165,18 @@ export interface Database<
       include: readonly Include[] | ReadonlySet<string>,
       options?: EntitySelectOptions<C, Pick<C & RequiredComponents, T>>
     ): Observe<readonly Entity[]>;
+    /**
+     * Reactive entity count for the same query as `observe.select` — emits a number and
+     * allocates no entity array, re-emitting only when the count changes. Prefer this over
+     * `observe.select(...).length` for membership/count-driven computeds.
+     */
+    count<
+      Include extends StringKeyof<C>,
+      T extends Include
+    >(
+      include: readonly Include[] | ReadonlySet<string>,
+      options?: EntitySelectOptions<C, Pick<C & RequiredComponents, T>>
+    ): Observe<number>;
   }
   /**
    * Reactive derivation. `compute` runs against a read-only projection of this

--- a/packages/data/src/ecs/database/observe-count-entities.test.ts
+++ b/packages/data/src/ecs/database/observe-count-entities.test.ts
@@ -1,0 +1,99 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { Database } from "./database.js";
+import { F32 } from "../../math/f32/index.js";
+import { Boolean } from "../../schema/index.js";
+
+describe("observeCountEntities", () => {
+    function createTestDatabase() {
+        return Database.create(Database.Plugin.create({
+            components: { position: F32.schema, health: F32.schema, active: Boolean.schema },
+            resources: {},
+            archetypes: {
+                Position: ["position"],
+                PositionHealth: ["position", "health"],
+                Active: ["active"],
+            },
+            transactions: {
+                addPosition(store, args: { position: number }) { return store.archetypes.Position.insert(args); },
+                addPositionHealth(store, args: { position: number, health: number }) { return store.archetypes.PositionHealth.insert(args); },
+                addActive(store, args: { active: boolean }) { return store.archetypes.Active.insert(args); },
+                update(store, args: { entity: number, values: any }) { return store.update(args.entity, args.values); },
+                remove(store, args: { entity: number }) { return store.delete(args.entity); },
+            },
+        }));
+    }
+
+    let db: ReturnType<typeof createTestDatabase>;
+    beforeEach(() => { db = createTestDatabase(); });
+
+    it("emits the initial count summed across matching archetypes", () => {
+        db.transactions.addPosition({ position: 1 });
+        db.transactions.addPositionHealth({ position: 2, health: 9 });
+        const observer = vi.fn();
+        const unobserve = db.observe.count(["position"])(observer);
+        expect(observer).toHaveBeenCalledTimes(1);
+        expect(observer).toHaveBeenLastCalledWith(2); // Position(1) + PositionHealth(1)
+        unobserve();
+    });
+
+    it("re-emits on entity add and delete", async () => {
+        const observer = vi.fn();
+        const unobserve = db.observe.count(["position"])(observer);
+        expect(observer).toHaveBeenLastCalledWith(0);
+
+        const e = db.transactions.addPosition({ position: 1 });
+        await Promise.resolve();
+        expect(observer).toHaveBeenLastCalledWith(1);
+
+        db.transactions.addPositionHealth({ position: 2, health: 5 });
+        await Promise.resolve();
+        expect(observer).toHaveBeenLastCalledWith(2);
+
+        db.transactions.remove({ entity: e });
+        await Promise.resolve();
+        expect(observer).toHaveBeenLastCalledWith(1);
+        unobserve();
+    });
+
+    it("does NOT re-emit when only a value changes (count unchanged)", async () => {
+        const e = db.transactions.addPosition({ position: 1 });
+        const observer = vi.fn();
+        const unobserve = db.observe.count(["position"])(observer);
+        expect(observer).toHaveBeenCalledTimes(1); // initial 1
+
+        db.transactions.update({ entity: e, values: { position: 999 } });
+        await Promise.resolve();
+        expect(observer).toHaveBeenCalledTimes(1); // membership unchanged → deduped
+        unobserve();
+    });
+
+    it("does NOT re-emit when an irrelevant component changes", async () => {
+        db.transactions.addPosition({ position: 1 });
+        const other = db.transactions.addActive({ active: true });
+        const observer = vi.fn();
+        const unobserve = db.observe.count(["position"])(observer);
+        expect(observer).toHaveBeenCalledTimes(1);
+
+        db.transactions.update({ entity: other, values: { active: false } });
+        await Promise.resolve();
+        expect(observer).toHaveBeenCalledTimes(1);
+        unobserve();
+    });
+
+    it("tracks a where-filtered count as rows cross the boundary", async () => {
+        const e = db.transactions.addActive({ active: false });
+        const observer = vi.fn();
+        const unobserve = db.observe.count(["active"], { where: { active: true } })(observer);
+        expect(observer).toHaveBeenLastCalledWith(0);
+
+        db.transactions.update({ entity: e, values: { active: true } });
+        await Promise.resolve();
+        expect(observer).toHaveBeenLastCalledWith(1);
+
+        db.transactions.update({ entity: e, values: { active: false } });
+        await Promise.resolve();
+        expect(observer).toHaveBeenLastCalledWith(0);
+        unobserve();
+    });
+});

--- a/packages/data/src/ecs/database/observe-count-entities.ts
+++ b/packages/data/src/ecs/database/observe-count-entities.ts
@@ -1,0 +1,80 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { Observe } from "../../observe/index.js";
+import { StringKeyof } from "../../types/types.js";
+import { RequiredComponents } from "../required-components.js";
+import { OptionalComponents, ReadonlyStore } from "../index.js";
+import { EntitySelectOptions } from "../store/entity-select-options.js";
+import { TransactionResult } from "./transactional-store/transactional-store.js";
+import { canonicalSelectKey } from "./observe-select-entities.js";
+
+/**
+ * The reactive counterpart of `store.count` — mirrors `observeSelectEntities` but emits the
+ * entity COUNT (a number) instead of an entity array, so a count-only consumer allocates no
+ * array on every change.
+ *
+ * On any commit that touches an `include`/`exclude` component it recomputes
+ * `store.count(include, options)` — cheap: a sum of matched archetype row counts — and emits
+ * only when the value actually changed. Unlike `observe.select` it keeps no per-entity
+ * membership set: ordering is irrelevant to a count, and a recompute that finds the same count
+ * (e.g. a value-only change on a member) is dropped by the value dedupe rather than avoided by
+ * a membership diff. Keyed identically to `observe.select` so equal queries share one Observe.
+ */
+export const observeCountEntities = <C extends object>(store: ReadonlyStore<C, any, any>, observeTransactions: Observe<TransactionResult<C>>) => {
+    const cachedCountObserveFunctions = new Map<string, Observe<number>>();
+
+    const createCountObserveFunction = <Include extends StringKeyof<C>>(
+        include: readonly Include[] | ReadonlySet<string>,
+        options?: EntitySelectOptions<C, Pick<C & RequiredComponents & OptionalComponents, Include>>
+    ): Observe<number> => {
+        return (observer: (count: number) => void) => {
+            const includeSet = new Set<string>(include);
+            const excludeSet = new Set<string>(options?.exclude ?? []);
+            let isMicrotaskQueued = false;
+            let hasEmitted = false;
+            let currentCount = 0;
+
+            const notifyObserver = () => {
+                isMicrotaskQueued = false;
+                const count = store.count(include, options);
+                if (!hasEmitted || count !== currentCount) {
+                    hasEmitted = true;
+                    currentCount = count;
+                    observer(count);
+                }
+            };
+
+            const unobserveTransactions = observeTransactions(t => {
+                if (t.changedComponents.isDisjointFrom(includeSet) && t.changedComponents.isDisjointFrom(excludeSet)) {
+                    // No selected or excluded component changed, so membership — and thus the count —
+                    // cannot have changed. (`where` keys are a subset of `include`, so a filter-value
+                    // change is already covered by the include test.)
+                    return;
+                }
+                if (!isMicrotaskQueued) {
+                    isMicrotaskQueued = true;
+                    queueMicrotask(notifyObserver);
+                }
+            });
+
+            notifyObserver();
+
+            return () => {
+                unobserveTransactions();
+            };
+        };
+    };
+
+    return <Include extends StringKeyof<C>>(
+        include: readonly Include[] | ReadonlySet<string>,
+        options?: EntitySelectOptions<C, Pick<C & RequiredComponents & OptionalComponents, Include>>
+    ) => {
+        const key = canonicalSelectKey(include, options);
+        let observeFunction = cachedCountObserveFunctions.get(key);
+        if (!observeFunction) {
+            observeFunction = Observe.withCache(createCountObserveFunction(include, options));
+            cachedCountObserveFunctions.set(key, observeFunction);
+        }
+        return observeFunction;
+    };
+};

--- a/packages/data/src/ecs/database/observe-select-entities.ts
+++ b/packages/data/src/ecs/database/observe-select-entities.ts
@@ -179,7 +179,7 @@ const ELEMENT = "\u0000";
  * matter); `where` is a conjunction (keys sorted, values JSON-serialized);
  * `order` is a sort-priority sequence (preserved as written).
  */
-const canonicalSelectKey = <C extends object, T extends object>(
+export const canonicalSelectKey = <C extends object, T extends object>(
     include: readonly string[] | ReadonlySet<string>,
     options?: EntitySelectOptions<C, T>,
 ): string => {

--- a/packages/data/src/ecs/database/observed/create-observed-database.ts
+++ b/packages/data/src/ecs/database/observed/create-observed-database.ts
@@ -11,6 +11,7 @@ import { Store } from "../../store/index.js";
 import { TransactionResult } from "../transactional-store/index.js";
 import { PersistenceScope, ToDataOptions } from "../../persistence-scope.js";
 import { observeSelectEntities } from "../observe-select-entities.js";
+import { observeCountEntities } from "../observe-count-entities.js";
 import { createDerive } from "../observe-derive.js";
 import { createTransactionalStore } from "../transactional-store/create-transactional-store.js";
 import { Entity } from "../../entity/entity.js";
@@ -146,6 +147,7 @@ export function createObservedDatabase<
         entity: observeEntity,
         archetype: observeArchetype,
         select: observeSelectEntities(transactionalStore, observeTransaction),
+        count: observeCountEntities(transactionalStore, observeTransaction),
     };
 
     const notifyAllObserversStoreReloaded = () => {

--- a/packages/data/src/ecs/database/observed/observed-database.ts
+++ b/packages/data/src/ecs/database/observed/observed-database.ts
@@ -33,6 +33,13 @@ export interface ObservedDatabase<
             include: readonly Include[] | ReadonlySet<string>,
             options?: any
         ): Observe<readonly Entity[]>;
+        count<
+            Include extends StringKeyof<C>,
+            T extends Include
+        >(
+            include: readonly Include[] | ReadonlySet<string>,
+            options?: any
+        ): Observe<number>;
     };
     // Internal (loose) type — the precise `Database.Read<this>` callback surface
     // is enforced at the public `Database.derive` boundary.

--- a/packages/data/src/ecs/store/core/count-entities.test.ts
+++ b/packages/data/src/ecs/store/core/count-entities.test.ts
@@ -1,0 +1,93 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, expect, it } from "vitest";
+import { countEntities } from "./count-entities.js";
+import { selectEntities } from "./select-entities.js";
+import { createCore } from "./create-core.js";
+import { Schema } from "../../../schema/index.js";
+import { F32 } from "../../../math/f32/index.js";
+
+const nameSchema = { type: "string" } as const satisfies Schema;
+const scoreSchema = { type: "number" } as const satisfies Schema;
+const activeSchema = { type: "boolean" } as const satisfies Schema;
+
+describe("countEntities", () => {
+    const core = createCore({
+        position: F32.schema,
+        health: F32.schema,
+        name: nameSchema,
+        score: scoreSchema,
+        active: activeSchema,
+    });
+
+    const positionArchetype = core.ensureArchetype(["position"]);
+    const healthArchetype = core.ensureArchetype(["health"]);
+    const nameArchetype = core.ensureArchetype(["name"]);
+    const positionHealthArchetype = core.ensureArchetype(["position", "health"]);
+    const positionNameArchetype = core.ensureArchetype(["position", "name"]);
+    const healthNameArchetype = core.ensureArchetype(["health", "name"]);
+    const fullArchetype = core.ensureArchetype(["position", "health", "name", "score", "active"]);
+
+    positionArchetype.insert({ position: 1 });
+    positionArchetype.insert({ position: 2 });
+    positionArchetype.insert({ position: 3 });
+    healthArchetype.insert({ health: 50 });
+    healthArchetype.insert({ health: 75 });
+    healthArchetype.insert({ health: 25 });
+    nameArchetype.insert({ name: "Alice" });
+    nameArchetype.insert({ name: "Bob" });
+    nameArchetype.insert({ name: "Charlie" });
+    positionHealthArchetype.insert({ position: 10, health: 80 });
+    positionHealthArchetype.insert({ position: 13, health: 90 });
+    positionNameArchetype.insert({ position: 16, name: "David" });
+    positionNameArchetype.insert({ position: 19, name: "Eve" });
+    healthNameArchetype.insert({ health: 60, name: "Frank" });
+    healthNameArchetype.insert({ health: 40, name: "Grace" });
+    fullArchetype.insert({ position: 22, health: 95, name: "Henry", score: 85.5, active: true });
+    fullArchetype.insert({ position: 25, health: 30, name: "Iris", score: 92.0, active: false });
+    fullArchetype.insert({ position: 28, health: 70, name: "Jack", score: 78.3, active: true });
+
+    describe("no where filter (sum of archetype row counts)", () => {
+        it("counts position across every archetype that has it", () => {
+            // pos(3) + posHealth(2) + posName(2) + full(3)
+            expect(countEntities(core, ["position"])).toBe(10);
+        });
+        it("counts an intersection: position + health", () => {
+            // posHealth(2) + full(3)
+            expect(countEntities(core, ["position", "health"])).toBe(5);
+        });
+        it("counts a component carried by one archetype", () => {
+            expect(countEntities(core, ["score"])).toBe(3); // full only
+        });
+        it("returns 0 when no archetype matches", () => {
+            expect(countEntities(core, ["position", "score", "name", "health", "active"], { exclude: ["position"] })).toBe(0);
+        });
+    });
+
+    it("respects exclude", () => {
+        // position minus those that also have name: pos(3) + posHealth(2); posName + full excluded
+        expect(countEntities(core, ["position"], { exclude: ["name"] })).toBe(5);
+    });
+
+    it("respects a where row filter", () => {
+        expect(countEntities(core, ["active"], { where: { active: true } })).toBe(2); // Henry, Jack
+        expect(countEntities(core, ["name"], { where: { name: "Alice" } })).toBe(1);
+        expect(countEntities(core, ["score"], { where: { score: { ">": 80 } } })).toBe(2); // 85.5, 92.0
+    });
+
+    it("equals selectEntities(...).length for every query shape", () => {
+        const queries: [readonly string[], Record<string, unknown>?][] = [
+            [["position"]],
+            [["health"]],
+            [["position", "health"]],
+            [["name"]],
+            [["score"]],
+            [["position"], { exclude: ["name"] }],
+            [["active"], { where: { active: true } }],
+            [["score"], { where: { score: { ">": 80 } } }],
+        ];
+        for (const [include, options] of queries) {
+            expect(countEntities(core, include as never, options as never))
+                .toBe(selectEntities(core, include as never, options as never).length);
+        }
+    });
+});

--- a/packages/data/src/ecs/store/core/count-entities.ts
+++ b/packages/data/src/ecs/store/core/count-entities.ts
@@ -1,0 +1,48 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { getRowPredicateFromFilter } from "../../../table/select-rows.js";
+import { StringKeyof } from "../../../types/types.js";
+import { RequiredComponents } from "../../required-components.js";
+import { EntitySelectOptions } from "../entity-select-options.js";
+import { Core } from "./core.js";
+import { OptionalComponents } from "../../optional-components.js";
+
+/**
+ * Count the entities matching `include` (minus `exclude`), applying an optional row
+ * `where` filter — the count-only counterpart of `selectEntities` in the same folder.
+ *
+ * Ordering is meaningless to a count, so there is no `order` handling. For the common
+ * no-`where` case the count is the sum of each matched archetype's `rowCount` (via
+ * `queryArchetypes`): O(matched archetypes), and — unlike `select` — it allocates no
+ * entity array. With a `where` filter it counts matching rows through the row predicate
+ * without collecting their ids.
+ */
+export const countEntities = <
+    C extends object,
+    Include extends StringKeyof<C & OptionalComponents>
+>(
+    core: Core<C>,
+    include: readonly Include[] | ReadonlySet<string>,
+    options?: EntitySelectOptions<C & RequiredComponents, Pick<C & RequiredComponents & OptionalComponents, Include>>
+): number => {
+    // Only `exclude` is an archetype-level option; `where` is a row-level filter applied below.
+    const archetypes = core.queryArchetypes(include, options?.exclude ? { exclude: options.exclude } : undefined);
+    if (!options?.where) {
+        let count = 0;
+        for (const archetype of archetypes) {
+            count += archetype.rowCount;
+        }
+        return count;
+    }
+    const predicate = getRowPredicateFromFilter(options.where);
+    let count = 0;
+    for (const archetype of archetypes) {
+        // `queryArchetypes` guarantees each archetype carries every `include` column, and
+        // `where` keys are a subset of `include`, so the predicate reads present columns.
+        const table = archetype as unknown as Parameters<typeof predicate>[0];
+        for (let row = 0; row < archetype.rowCount; row++) {
+            if (predicate(table, row)) count++;
+        }
+    }
+    return count;
+};

--- a/packages/data/src/ecs/store/public/create-store.ts
+++ b/packages/data/src/ecs/store/public/create-store.ts
@@ -14,6 +14,7 @@ import { ResourceSchemas } from "../../resource-schemas.js";
 import { ArchetypeComponents } from "../archetype-components.js";
 import { EntitySelectOptions } from "../entity-select-options.js";
 import { selectEntities } from "../core/select-entities.js";
+import { countEntities } from "../core/count-entities.js";
 import { OptionalComponents } from "../../optional-components.js";
 import {
     createIndexRegistry,
@@ -209,6 +210,15 @@ export function createStore<
         return selectEntities<C, Include>(core, include, options);
     }
 
+    const count = <
+        Include extends StringKeyof<C & OptionalComponents>
+    >(
+        include: readonly Include[] | ReadonlySet<string>,
+        options?: EntitySelectOptions<C & OptionalComponents, Pick<C & RequiredComponents & OptionalComponents, Include>>
+    ): number => {
+        return countEntities<C, Include>(core, include, options);
+    }
+
     const archetypes = {} as any;
 
     // Decorate an archetype's `insert` in place with index maintenance. The core
@@ -337,6 +347,7 @@ export function createStore<
         delete: deleteEntity,
         resources,
         select,
+        count,
         archetypes,
         indexes: indexHandles as any,
         extend,

--- a/packages/data/src/ecs/store/store.ts
+++ b/packages/data/src/ecs/store/store.ts
@@ -29,6 +29,17 @@ interface BaseStore<C extends object = never> {
         options?: EntitySelectOptions<C & OptionalComponents, Pick<C & RequiredComponents & OptionalComponents, Include>>
     ): readonly Entity[];
     /**
+     * Count the entities `select` would return for the same arguments — without building
+     * an entity array. With no `where` filter it sums matched archetype row counts
+     * (O(matched archetypes)); `order` is ignored (irrelevant to a count).
+     */
+    count<
+        Include extends StringKeyof<C & OptionalComponents>
+    >(
+        include: readonly Include[] | ReadonlySet<string>,
+        options?: EntitySelectOptions<C & OptionalComponents, Pick<C & RequiredComponents & OptionalComponents, Include>>
+    ): number;
+    /**
      * Serialize the store to a plain snapshot. When `copy` is true the snapshot
      * is detached from the live store (column/entity buffers are copied) so it
      * remains valid after subsequent mutations; otherwise it references live


### PR DESCRIPTION
## Summary

Adds `store.count(include, options)` and reactive `db.observe.count(...)` to the ECS — the count-only counterparts of `select` / `observe.select`.

## Motivation

`db.observe.select(archetype.components)` allocates a fresh `Entity[]` on every membership change; a consumer that only needs *how many* entities match (empty-state flags, badge counts) throws that array away to read `.length`. `count` returns the number directly with no entity-array allocation.

## What it does

- **`store.count(include, options)`** (sync). No `where`: sums each matched archetype's `rowCount` via `queryArchetypes` — O(matched archetypes), zero allocation. `order` is irrelevant to a count, so there is no ordered branch. With `where`: counts matching rows through the row predicate without collecting ids.
- **`db.observe.count(...)` → `Observe<number>`** (reactive). Recomputes the cheap count on any commit touching an `include`/`exclude` component and emits only when the value changes. No per-entity membership set — coarser than `observe.select`'s optimizer, but allocation-free; a redundant recompute (e.g. a value-only change on a member) is dropped by the value dedupe.

Wired through `BaseStore` / `Database.observe` / `ObservedDatabase.observe`, keyed identically to `observe.select` so equal queries share one Observe. Documented in the data-ai `ecs.md` + `computed.md` rules so agents prefer it over `select(...).length`.

## Tests

- `count-entities.test.ts` — sums, exclude, where; asserts equality with `selectEntities(...).length` across query shapes.
- `observe-count-entities.test.ts` — initial emit, re-emit on add/delete, no re-emit on value-only change (deduped), no re-emit on irrelevant change, where-boundary tracking.
- All 635 store + database tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)