### PR TITLE
fix(data): remap archetype ids on load so schema changes don't corrupt entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-persistence/src/service/create-incremental-persistence-service.ts
+++ b/packages/data-persistence/src/service/create-incremental-persistence-service.ts
@@ -991,7 +991,12 @@ export const createIncrementalPersistenceService = async (
                 if (idColumn === undefined) continue;
                 const entity = Entity.toEntity(slot, quadrant);
                 idColumn.set(rowIndex, entity);
-                locations.push({ entity, archetype: archetypeId, row: rowIndex });
+                // `archetypeId` is the id this session's on-disk manifest
+                // recorded at the time of the last checkpoint/journal entry —
+                // it can differ from `liveArchetype.id` if the plugin's
+                // archetype declarations changed shape since. Persist the
+                // resolved live id, not the stale on-disk one.
+                locations.push({ entity, archetype: liveArchetype.id, row: rowIndex });
             }
         }
 

--- a/packages/data-persistence/src/service/load-roundtrip.test.ts
+++ b/packages/data-persistence/src/service/load-roundtrip.test.ts
@@ -1,6 +1,7 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 import { Database } from "@adobe/data/ecs";
 import { F32, Vec3 } from "@adobe/data/math";
+import type { Schema } from "@adobe/data/schema";
 import { describe, expect, it } from "vitest";
 import { createMemoryBackend } from "../backend/memory-backend.js";
 import { createWorkerPersistenceService } from "./create-worker-persistence-service.js";
@@ -252,6 +253,84 @@ describe("WorkerPersistenceService.load (round-trip)", () => {
                 mass: i * 0.5,
             });
         }
+        await svcB.dispose();
+    });
+
+    it("BUG: corrupts entity reads when the reloading plugin declares a new archetype ahead of an existing one", async () => {
+        const backend = createMemoryBackend();
+
+        // v1: a single archetype "Particle" -> claims manifest/live id 0.
+        const pluginV1 = Database.Plugin.create({
+            components: { position: Vec3.schema, velocity: Vec3.schema, mass: F32.schema },
+            archetypes: { Particle: ["position", "velocity", "mass"] },
+            transactions: {
+                spawn(t, args: { x: number; y: number; z: number; mass: number }) {
+                    return t.archetypes.Particle.insert({
+                        position: [args.x, args.y, args.z],
+                        velocity: [0, 0, 0],
+                        mass: args.mass,
+                    });
+                },
+            },
+        });
+
+        const dbA = Database.create(pluginV1);
+        const svcA = await createWorkerPersistenceService({
+            database: dbA,
+            backend,
+            checkpoint: { everyNTransactions: 0, idleMs: 0 },
+        });
+        const e = dbA.transactions.spawn({ x: 1, y: 2, z: 3, mass: 10 });
+        await svcA.flush();
+        await svcA.checkpoint();
+        await svcA.dispose();
+
+        // v2: schema evolves by adding a new archetype "Tag", declared BEFORE
+        // "Particle" in the plugin's archetypes object. Store.extend() creates
+        // archetypes in declaration order before load() ever runs, so on the
+        // fresh v2 database "Tag" claims id 0 and "Particle" is pushed to id
+        // 1 -- one slot later than the id recorded in the v1 checkpoint.
+        const tagSchema = { type: "boolean", default: false } satisfies Schema;
+        const pluginV2 = Database.Plugin.create({
+            components: { position: Vec3.schema, velocity: Vec3.schema, mass: F32.schema, tag: tagSchema },
+            archetypes: {
+                Tag: ["tag"],
+                Particle: ["position", "velocity", "mass"],
+            },
+            transactions: {
+                spawn(t, args: { x: number; y: number; z: number; mass: number }) {
+                    return t.archetypes.Particle.insert({
+                        position: [args.x, args.y, args.z],
+                        velocity: [0, 0, 0],
+                        mass: args.mass,
+                    });
+                },
+            },
+        });
+
+        const dbB = Database.create(pluginV2);
+        const svcB = await createWorkerPersistenceService({
+            database: dbB,
+            backend,
+            checkpoint: { everyNTransactions: 0, idleMs: 0 },
+        });
+        await svcB.load();
+
+        // The entity-location file on disk still says "archetype 0" (Particle's
+        // OLD id), but archetype 0 in dbB is now Tag. The entity must still
+        // read back as the particle it was saved as.
+        const view = dbB.read(e!) as
+            | { position: ArrayLike<number>; velocity: ArrayLike<number>; mass: number }
+            | null;
+        expect(view).not.toBeNull();
+        if (view === null) return;
+        // Corrupted state resolves the entity into "Tag" (no position column)
+        // instead of "Particle" -- assert the field directly so the failure
+        // reads as "position is undefined" rather than an iteration crash.
+        expect(view.position).toBeDefined();
+        expect(Array.from(view.position)).toEqual([1, 2, 3]);
+        expect(Array.from(view.velocity)).toEqual([0, 0, 0]);
+        expect(view.mass).toBe(10);
         await svcB.dispose();
     });
 });

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/entity-location-table/create-entity-location-table.ts
+++ b/packages/data/src/ecs/entity-location-table/create-entity-location-table.ts
@@ -113,3 +113,33 @@ const createLocalIndexEntityLocationTable = (initialCapacity: number = 16): Enti
         }
     };
 }
+
+/**
+ * Return a copy of a serialized location-table snapshot (the shape `toData`
+ * produces) with every entry's stored archetype id translated through
+ * `archetypeIdMap` (`archetypeIdMap[oldId] ?? oldId`).
+ *
+ * A serialized archetype id is a dense array index captured at save time; the
+ * archetype occupying that index can differ by the time of restore — a schema
+ * change may have added, removed, or reordered an archetype — so the raw id is
+ * not stable across a save/load boundary. Free-list markers (negative archetype
+ * slots), `freeListHead`, `nextIndex`, and `capacity` are preserved exactly, so
+ * the restored table allocates ids identically to the source. The remap is
+ * applied to a fresh buffer (never in place): the input may reference the live
+ * buffer of the store that produced it.
+ */
+export const remapSerializedArchetypeIds = (
+    data: unknown,
+    archetypeIdMap: readonly number[],
+): unknown => {
+    // Runtime invariant: `data` is a snapshot produced by this module's `toData`.
+    const table = data as { entities: Int32Array; freeListHead: number; nextIndex: number; capacity: number };
+    const src = table.entities;
+    const entities = new Int32Array(src.length);
+    for (let i = 0; i < src.length; i += 2) {
+        const archetype = src[i]!;
+        entities[i] = archetype < 0 ? archetype : (archetypeIdMap[archetype] ?? archetype);
+        entities[i + 1] = src[i + 1]!;
+    }
+    return { ...table, entities };
+};

--- a/packages/data/src/ecs/store/core/create-core.ts
+++ b/packages/data/src/ecs/store/core/create-core.ts
@@ -1,7 +1,7 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
 import { Schema } from "../../../schema/index.js";
-import { createEntityLocationTable } from "../../entity-location-table/index.js";
+import { createEntityLocationTable, remapSerializedArchetypeIds } from "../../entity-location-table/index.js";
 import * as ARCHETYPE from "../../archetype/index.js";
 import { Table, addRow, updateRow } from "../../../table/index.js";
 // getRowData returns the WHOLE row (incl. the internal `id` column); it is only
@@ -568,26 +568,43 @@ export function createCore<NC extends ComponentSchemas>(
                     }
                 }
             }
-            for (const quadrant of scopeQuadrants(scope)) {
-                const restored = data.entityLocationTables[quadrant];
-                // Restore the quadrant's table, or reset it if the snapshot
-                // carried no entities for it.
-                if (restored !== undefined) {
-                    locationTables[quadrant]!.fromData(restored);
-                } else {
-                    locationTables[quadrant]!.reset();
-                }
-            }
+            // Resolve every persisted archetype BEFORE touching the location
+            // tables. resolveArchetype is identity-keyed (component names +
+            // partition values), not position-keyed, so a persisted
+            // archetype's array position at save time (its serialized id)
+            // can resolve to a *different* live id now — e.g. a schema
+            // change added, removed, or reordered an archetype relative to
+            // this one. `archetypeIdMap[oldId]` is that archetype's current
+            // id; the location tables restore through it below so a stale
+            // save-time id never lands in the live table.
+            const archetypeIdMap: number[] = [];
             const restoredArchetypes: Archetype<any>[] = [];
             for (const { componentNames, partitionValues, data: archetypeData } of data.archetypesData) {
-                // Recreating the archetype reserves its id and leaves it empty
-                // (keeping ids aligned); only in-scope entries carry data to
-                // restore. resolveArchetype (not the public ensureArchetype) so a
+                // resolveArchetype (not the public ensureArchetype) so a
                 // partition archetype restores as its concrete value-child.
                 const archetype = resolveArchetype(componentNames, partitionValues);
+                archetypeIdMap.push(archetype.id);
                 if (archetypeData !== undefined) {
                     archetype.fromData(archetypeData);
                     restoredArchetypes.push(archetype as unknown as Archetype<any>);
+                }
+            }
+            for (const quadrant of scopeQuadrants(scope)) {
+                const restored = data.entityLocationTables[quadrant];
+                // Restore the quadrant's table, or reset it if the snapshot
+                // carried no entities for it. When any archetype resolved to a
+                // different id than its serialized position (schema change), the
+                // stored ids are translated first; with no archetypes to map
+                // (e.g. a persistence-layer table already carrying live ids) the
+                // snapshot is restored verbatim.
+                if (restored !== undefined) {
+                    locationTables[quadrant]!.fromData(
+                        archetypeIdMap.length > 0
+                            ? remapSerializedArchetypeIds(restored, archetypeIdMap)
+                            : restored,
+                    );
+                } else {
+                    locationTables[quadrant]!.reset();
                 }
             }
             // The archetypes just loaded had their nonPersistent columns omitted

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -794,6 +794,35 @@ describe("createStore", () => {
             expect(newStore.read(positionEntity)).toEqual({ position: 42 });
         });
 
+        it("BUG: corrupts entity reads when a schema-declared archetype is added ahead of an existing one", () => {
+            // v1: a single named archetype "A", declared alone -> gets id 0.
+            const v1 = createStore({
+                components: { health: healthSchema },
+                resources: {},
+                archetypes: { A: ["health"] },
+            });
+            const entity = v1.archetypes.A.insert({ health: { current: 100, max: 100 } });
+            const snapshot = v1.toData({ copy: true });
+
+            // v2: schema evolves by adding a new archetype "B" declared BEFORE
+            // "A" in the schema object. createStore's own extend() pre-creates
+            // archetypes for every schema-declared entry (in declaration order)
+            // before fromData ever runs, so on the fresh v2 store, B claims id 0
+            // and A is pushed to id 1 -- one slot later than it occupied when
+            // the snapshot was taken.
+            const v2 = createStore({
+                components: { name: nameSchema, health: healthSchema },
+                resources: {},
+                archetypes: { B: ["name"], A: ["health"] },
+            });
+            v2.fromData(snapshot);
+
+            // The entity's location table entry still says "archetype 0" (A's
+            // OLD position), but archetype 0 in v2 is now B, not A. The entity
+            // must still read back as itself.
+            expect(v2.read(entity)).toEqual({ health: { current: 100, max: 100 } });
+        });
+
         it("stamps a version and skips (warns, does not throw) snapshots of an incompatible or legacy format", () => {
             const store = createStore({ components: { position: positionSchema }, resources: {}, archetypes: {} });
             const entity = store.ensureArchetype(["position"]).insert({ position: { x: 1, y: 2, z: 3 } });


### PR DESCRIPTION
## Summary

Fixes a silent data-corruption class in persistence load: an archetype's id is its dense index in the `archetypes` array, written **by value** into the entity-location table. On load, archetypes are resolved by **identity** (component set + partition values), not by their serialized array position. So any schema change that adds, removes, or reorders an archetype resolves a persisted archetype to a *different live id* than the position it was saved at — and the never-remapped location-table indices then point entities at the **wrong archetype**. No throw, just wrong reads (a prior production incident class).

Two independent code paths had this bug:

1. **In-memory `Store`/`Core` snapshot restore** (`create-core.ts`) — `createStore(schema)` eagerly creates archetypes for every schema-declared archetype/resource *before* `fromData` runs, in declaration order, so ids desync from serialized positions whenever the declaration order changes.
2. **Incremental/journal persistence service** (`create-incremental-persistence-service.ts`) — `finalizeEntityLocationTable` pushed the raw on-disk manifest `archetypeId` straight into the restored location table with no translation, even though it already resolves the live archetype by name.

## Fix

- `core.fromData` resolves every persisted archetype **first**, building an `oldPosition → liveId` map, then translates the location table's stored ids through it via `remapSerializedArchetypeIds` — a pure transform co-located with the serialized-blob format (the generic `EntityLocationTable` interface is untouched).
- The persistence service writes the resolved `liveArchetype.id` (looked up by name from the manifest) instead of the stale on-disk id.

**No serialization format change** (ECS snapshot version stays `2`, manifest stays `1`): this is purely load-time reconciliation. Existing snapshots load correctly — and now correctly *under a schema change*.

## Tests

Added a red-first regression test per path, each reproducing the exact corruption (an entity saved in archetype A reads back as unrelated archetype B after a schema/plugin archetype is declared ahead of it), now green:

- `packages/data/src/ecs/store/public/create-store.test.ts`
- `packages/data-persistence/src/service/load-roundtrip.test.ts`

Full suites pass: **3055** data + **240** persistence tests; monorepo lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)