### PR TITLE
feat(data): pruneToPluginSchema + fromData sheds empty structural residue

### DIFF
--- a/packages/data/src/ecs/database/database.prune.test.ts
+++ b/packages/data/src/ecs/database/database.prune.test.ts
@@ -1,0 +1,101 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+//
+// Red/green tests for Database.pruneToPluginSchema — conforming a database's
+// DATA to a target plugin, with the empty foreign structure shed on the next
+// load (not by an in-place rebuild).
+
+import { describe, it, expect } from "vitest";
+import { Database } from "./database.js";
+import type { Schema } from "../../schema/index.js";
+
+const num = { type: "number", default: 0 } as const satisfies Schema;
+
+// The target schema we prune TO.
+const targetPlugin = Database.Plugin.create({
+    components: { a: num, b: num },
+    resources: { keptRes: { default: 0 as number } },
+    archetypes: { AB: ["a", "b"] } as const,
+    transactions: {
+        addAB(t, args: { a: number; b: number }) {
+            return t.archetypes.AB.insert(args);
+        },
+        setKept(t, v: number) {
+            t.resources.keptRes = v;
+        },
+    },
+});
+
+// The full schema: target + a foreign component `c`, foreign resource, and
+// foreign archetypes.
+const fullPlugin = Database.Plugin.create({
+    extends: targetPlugin,
+    components: { c: num },
+    resources: { foreignRes: { default: 0 as number } },
+    archetypes: { ABC: ["a", "b", "c"], COnly: ["c"] } as const,
+    transactions: {
+        addABC(t, args: { a: number; b: number; c: number }) {
+            return t.archetypes.ABC.insert(args);
+        },
+        addCOnly(t, args: { c: number }) {
+            return t.archetypes.COnly.insert(args);
+        },
+        setForeign(t, v: number) {
+            t.resources.foreignRes = v;
+        },
+    },
+});
+
+describe("Database.pruneToPluginSchema", () => {
+    it("strips foreign data, deletes only-foreign entities, drops foreign resources, and sheds foreign structure on reload", () => {
+        const db = Database.create(fullPlugin);
+        const eAB = db.transactions.addAB({ a: 1, b: 2 });
+        const eABC = db.transactions.addABC({ a: 3, b: 4, c: 5 });
+        const eCOnly = db.transactions.addCOnly({ c: 9 });
+        db.transactions.setKept(7);
+        db.transactions.setForeign(99);
+
+        db.pruneToPluginSchema(targetPlugin);
+
+        // Declared entity untouched; mixed entity keeps declared data, loses `c`;
+        // an entity whose every component is foreign is gone.
+        expect(db.read(eAB)).toEqual({ a: 1, b: 2 });
+        expect(db.read(eABC)).toEqual({ a: 3, b: 4 });
+        expect(db.read(eCOnly)).toBeNull();
+
+        // Declared resource preserved; foreign resource retired (value + accessor).
+        expect(db.resources.keptRes).toBe(7);
+        expect((db.resources as Record<string, unknown>).foreignRes).toBeUndefined();
+
+        // The pruned document, reloaded into a target-only database, carries zero
+        // foreign trace, while entity ids and declared data survive the round-trip.
+        const pruned = db.toData();
+        const target = Database.create(targetPlugin);
+        target.fromData(pruned);
+        expect(target.read(eAB)).toEqual({ a: 1, b: 2 });
+        expect(target.read(eABC)).toEqual({ a: 3, b: 4 });
+        expect(target.resources.keptRes).toBe(7);
+
+        const reserialized = target.toData() as {
+            componentSchemas: Record<string, unknown>;
+            archetypesData: readonly { componentNames: readonly string[] }[];
+        };
+        expect("c" in reserialized.componentSchemas).toBe(false);
+        expect("foreignRes" in reserialized.componentSchemas).toBe(false);
+        for (const arch of reserialized.archetypesData) {
+            expect(arch.componentNames).not.toContain("c");
+            expect(arch.componentNames).not.toContain("foreignRes");
+        }
+    });
+
+    it("keeps the database usable after prune: declared transactions still run", () => {
+        const db = Database.create(fullPlugin);
+        db.transactions.addABC({ a: 1, b: 2, c: 3 });
+
+        db.pruneToPluginSchema(targetPlugin);
+
+        // A declared transaction still works and its result is observable.
+        const e = db.transactions.addAB({ a: 10, b: 20 });
+        expect(db.read(e)).toEqual({ a: 10, b: 20 });
+        expect(db.select(["a", "b"]).length).toBe(2); // migrated ABC entity + new AB entity
+    });
+});

--- a/packages/data/src/ecs/database/database.prune.type-test.ts
+++ b/packages/data/src/ecs/database/database.prune.type-test.ts
@@ -1,0 +1,60 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+//
+// Type-only tests for Database.pruneToPluginSchema's generic return type.
+// Nothing here executes — the file is a compile-time (red/green) check that
+// `pruneToPluginSchema<P>(plugin: P)` returns `Database.FromPlugin<P>`, i.e. the
+// same instance retyped to the *target* plugin's schema. `@ts-expect-error`
+// marks the assignments that must NOT type-check.
+
+import { Database } from "./database.js";
+
+const numeric = { type: "number", default: 0 } as const;
+
+// The simpler (target) schema.
+const simplePlugin = Database.Plugin.create({
+    components: { a: numeric },
+    resources: { keptRes: { default: 0 as number } },
+    archetypes: { A: ["a"] } as const,
+    transactions: {
+        addA(t, args: { a: number }) {
+            return t.archetypes.A.insert(args);
+        },
+    },
+});
+
+// A larger schema that extends the simpler one and adds a foreign component,
+// archetype, and transaction.
+const fullPlugin = Database.Plugin.create({
+    extends: simplePlugin,
+    components: { c: numeric },
+    archetypes: { AC: ["a", "c"] } as const,
+    transactions: {
+        addAC(t, args: { a: number; c: number }) {
+            return t.archetypes.AC.insert(args);
+        },
+    },
+});
+
+// Wrapped in a never-called function: purely a type-level assertion site.
+function _pruneReturnTypeChecks(): void {
+    const full = Database.create(fullPlugin);
+
+    // POSITIVE — pruning the wider database to the simpler plugin yields a value
+    // assignable to `Database.FromPlugin<typeof simplePlugin>`, and its declared
+    // surface is usable through the narrowed type.
+    const pruned: Database.FromPlugin<typeof simplePlugin> = full.pruneToPluginSchema(simplePlugin);
+    pruned.transactions.addA({ a: 1 });
+    void pruned.resources.keptRes;
+
+    // NEGATIVE — the pruned type is narrower than the full schema, so it must NOT
+    // be assignable to `Database.FromPlugin<typeof fullPlugin>` (that would claim
+    // the pruned-away `c` / `addAC` surface still exists in the type).
+    // @ts-expect-error pruned schema is narrower than the full plugin's schema
+    const wide: Database.FromPlugin<typeof fullPlugin> = full.pruneToPluginSchema(simplePlugin);
+    void wide;
+
+    // NEGATIVE — a foreign transaction is not part of the pruned (target) type.
+    // @ts-expect-error `addAC` was pruned away and is no longer in the type
+    pruned.transactions.addAC({ a: 1, c: 2 });
+}
+void _pruneReturnTypeChecks;

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -285,8 +285,13 @@ export interface Database<
    * skips empty archetypes and adopts only schemas the restored data uses), so
    * no snapshot round-trip carries them forever. Call when quiescent (no
    * in-flight transient); any pending transient is cleared, as with `reset`.
+   *
+   * Returns the same database instance retyped to the target plugin's schema
+   * (`Database.FromPlugin<P>`), so a wider database narrows to the pruned schema
+   * at the type level. Foreign behavior (transactions/systems the original
+   * plugin declared) still exists at runtime but is no longer in the type.
    */
-  pruneToPluginSchema(plugin: Database.Plugin): void
+  pruneToPluginSchema<P extends Database.Plugin>(plugin: P): Database.FromPlugin<P>
   extend<P extends Database.Plugin>(plugin: P): Database<
     C & FromSchemas<RemoveIndex<P['components']>>,
     R & FromSchemas<RemoveIndex<P['resources']>>,

--- a/packages/data/src/ecs/database/database.ts
+++ b/packages/data/src/ecs/database/database.ts
@@ -273,6 +273,20 @@ export interface Database<
    */
   toData(options?: { readonly scope?: PersistenceScope }): unknown
   fromData(data: unknown, scope?: PersistenceScope): void
+  /**
+   * Conform the database's DATA to a target plugin's schema, dropping every
+   * component and resource the plugin does not declare (its imports/extends are
+   * already flattened in). An entity keeping at least one declared component
+   * migrates to its reduced archetype; an entity whose every component is
+   * foreign — including a foreign resource singleton — is removed.
+   *
+   * Prunes DATA only, in place: the emptied foreign archetypes and their unused
+   * schemas are left as inert residue and shed on the next `fromData` (which
+   * skips empty archetypes and adopts only schemas the restored data uses), so
+   * no snapshot round-trip carries them forever. Call when quiescent (no
+   * in-flight transient); any pending transient is cleared, as with `reset`.
+   */
+  pruneToPluginSchema(plugin: Database.Plugin): void
   extend<P extends Database.Plugin>(plugin: P): Database<
     C & FromSchemas<RemoveIndex<P['components']>>,
     R & FromSchemas<RemoveIndex<P['resources']>>,

--- a/packages/data/src/ecs/database/observed/create-observed-database.ts
+++ b/packages/data/src/ecs/database/observed/create-observed-database.ts
@@ -196,6 +196,21 @@ export function createObservedDatabase<
             store.fromData(data, scope);
             notifyAllObserversStoreReloaded();
         },
+        pruneToSchema: (keep: ReadonlySet<string>) => {
+            transactionalStore.pruneToSchema(keep);
+            // Prune can drop components/resources, so rebuild the observable maps
+            // (mirror of extend) and notify — pruned entities/resources are a
+            // whole-store reload from every observer's point of view.
+            (observe as any).components = mapEntries(store.componentSchemas, ([component]) => addToMapSet(component, componentObservers));
+            (observe as any).resources = Object.fromEntries(
+                Object.entries(store.resources).map(([resource]) => {
+                    const archetype = store.ensureArchetype(resourceArchetypeComponents(resource));
+                    const resourceId = archetype.columns[ID].get(0);
+                    return [resource, Observe.withMap(observeEntity(resourceId), (values) => (values as any)?.[resource] ?? null)];
+                })
+            );
+            notifyAllObserversStoreReloaded();
+        },
         extend: (plugin: any) => {
             transactionalStore.extend(plugin);
             // Rebuild observe.components and observe.resources so new components/resources from extend are observable

--- a/packages/data/src/ecs/database/observed/observed-database.ts
+++ b/packages/data/src/ecs/database/observed/observed-database.ts
@@ -50,6 +50,7 @@ export interface ObservedDatabase<
     ): Observe<T>;
     readonly execute: (handler: (ctx: Store<C, R, A>) => Entity | void, options?: { transient?: boolean; userId?: number | string }) => TransactionResult<C>;
     readonly reset: () => void;
+    readonly pruneToSchema: (keep: ReadonlySet<string>) => void;
     readonly toData: (options?: ToDataOptions) => unknown;
     readonly fromData: (data: unknown, scope?: PersistenceScope) => void;
     readonly extend: <

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -174,6 +174,9 @@ function createEmptyDatabase(concurrency: ConcurrencyStrategyFactory | undefined
             ]);
             strategy.onReset();
             observedDatabase.pruneToSchema(keep);
+            // Same instance, retyped to the target plugin's schema at the type
+            // level (see Database.pruneToPluginSchema).
+            return partialDatabase;
         },
         toData,
         fromData,

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -162,6 +162,19 @@ function createEmptyDatabase(concurrency: ConcurrencyStrategyFactory | undefined
             strategy.onReset();
             observedDatabase.reset();
         },
+        pruneToPluginSchema: (plugin: Database.Plugin) => {
+            // The keep-set is the plugin's declared component + resource names
+            // (already flattened across imports/extends at plugin creation). The
+            // ECS built-ins are always kept by the store. Any in-flight transient
+            // is invalidated by the structural change, so clear the strategy's
+            // pending buffer, exactly as reset() does.
+            const keep = new Set<string>([
+                ...Object.keys(plugin.components ?? {}),
+                ...Object.keys(plugin.resources ?? {}),
+            ]);
+            strategy.onReset();
+            observedDatabase.pruneToSchema(keep);
+        },
         toData,
         fromData,
         transactions,

--- a/packages/data/src/ecs/database/transactional-store/create-transactional-store.ts
+++ b/packages/data/src/ecs/database/transactional-store/create-transactional-store.ts
@@ -194,6 +194,9 @@ export function createTransactionalStore<
                 updateEntity(entityId, { [resourceId]: newValue } as any);
             },
             enumerable: true,
+            // Configurable so pruneToSchema can drop a retired resource's accessor
+            // (mirrors the base store's resource definitions).
+            configurable: true,
         });
     }
 
@@ -281,6 +284,18 @@ export function createTransactionalStore<
         ...store,
         execute,
         transactionStore,
+        // Prune the base store, then sync the transactional resource wrapper by
+        // dropping any resource the base store no longer exposes (mirror of the
+        // additive sync in `extend`). Archetype ids are unchanged by prune, so the
+        // lazily-wrapped archetype handles stay valid.
+        pruneToSchema: (keep: ReadonlySet<string>) => {
+            store.pruneToSchema(keep);
+            for (const name of Object.keys(resources)) {
+                if (!Object.hasOwn(store.resources, name)) {
+                    delete (resources as Record<string, unknown>)[name];
+                }
+            }
+        },
         // Override extend to sync wrapped archetypes and resources after extending base store
         extend: (plugin: any) => {
             store.extend(plugin);
@@ -302,6 +317,7 @@ export function createTransactionalStore<
                             updateEntity(entityId, { [resourceId]: newValue } as any);
                         },
                         enumerable: true,
+                        configurable: true,
                     });
                 }
             }

--- a/packages/data/src/ecs/database/transactional-store/transactional-store.ts
+++ b/packages/data/src/ecs/database/transactional-store/transactional-store.ts
@@ -46,6 +46,9 @@ export interface TransactionalStore<
     >;
 
     transactionStore: Store<C, R, A, IX, PK>;
+
+    /** See {@link Store.pruneToSchema}. Also syncs the transactional resource wrapper. */
+    pruneToSchema(keep: ReadonlySet<string>): void;
 }
 
 export type TransactionInsertOperation<C> = {

--- a/packages/data/src/ecs/store/core/create-core.ts
+++ b/packages/data/src/ecs/store/core/create-core.ts
@@ -552,7 +552,10 @@ export function createCore<NC extends ComponentSchemas>(
                 );
                 return;
             }
-            Object.assign(componentSchemas, data.componentSchemas);
+            // Component schemas are adopted per-restored-archetype below (not
+            // wholesale here), so a schema no restored data uses does not
+            // round-trip, and the loading store's own declared schema always
+            // wins over the snapshot's.
             // A whole-database load (no scope) also reverts the non-persistent
             // quadrants to defaults, so the loading store's pre-load transient
             // values don't leak across the load. A scoped load is surgical: it
@@ -568,26 +571,50 @@ export function createCore<NC extends ComponentSchemas>(
                     }
                 }
             }
-            // Resolve every persisted archetype BEFORE touching the location
-            // tables. resolveArchetype is identity-keyed (component names +
-            // partition values), not position-keyed, so a persisted
-            // archetype's array position at save time (its serialized id)
-            // can resolve to a *different* live id now — e.g. a schema
-            // change added, removed, or reordered an archetype relative to
-            // this one. `archetypeIdMap[oldId]` is that archetype's current
-            // id; the location tables restore through it below so a stale
+            // Resolve the persisted (non-empty) archetypes BEFORE touching the
+            // location tables. resolveArchetype is identity-keyed (component names
+            // + partition values), not position-keyed, so a persisted archetype's
+            // array position at save time (its serialized id) can resolve to a
+            // *different* live id now — e.g. a schema change added, removed, or
+            // reordered an archetype relative to this one. `archetypeIdMap[oldId]`
+            // is that archetype's current id (or a placeholder for a skipped empty
+            // one); the location tables restore through it below so a stale
             // save-time id never lands in the live table.
             const archetypeIdMap: number[] = [];
             const restoredArchetypes: Archetype<any>[] = [];
+            const snapshotSchemas = data.componentSchemas as Record<string, Schema>;
+            const liveSchemas = componentSchemas as Record<string, Schema>;
             for (const { componentNames, partitionValues, data: archetypeData } of data.archetypesData) {
+                // Skip empty archetypes. An archetype with no rows is referenced
+                // by no location-table entry, so the remap never needs its id, and
+                // recreating it would resurrect structural residue — the empty
+                // archetypes a prior `pruneToSchema` left behind, or any archetype
+                // no live data uses. A still-needed (declared) archetype is
+                // recreated on demand. The id map keeps a placeholder so later,
+                // non-empty positions still translate correctly.
+                const rowCount = archetypeData === undefined
+                    ? 0
+                    : (archetypeData as { rowCount?: number }).rowCount ?? 0;
+                if (rowCount === 0) {
+                    archetypeIdMap.push(-1);
+                    continue;
+                }
+                // Adopt component schemas ONLY for components this restored data
+                // actually carries, and only when the loading store hasn't already
+                // declared them (its own schema wins). Unknown-but-populated
+                // components are preserved losslessly; unknown-and-unused schemas
+                // simply fall away instead of round-tripping forever.
+                for (const name of componentNames) {
+                    if (!(name in liveSchemas) && snapshotSchemas[name] !== undefined) {
+                        liveSchemas[name] = snapshotSchemas[name]!;
+                    }
+                }
                 // resolveArchetype (not the public ensureArchetype) so a
                 // partition archetype restores as its concrete value-child.
                 const archetype = resolveArchetype(componentNames, partitionValues);
                 archetypeIdMap.push(archetype.id);
-                if (archetypeData !== undefined) {
-                    archetype.fromData(archetypeData);
-                    restoredArchetypes.push(archetype as unknown as Archetype<any>);
-                }
+                archetype.fromData(archetypeData);
+                restoredArchetypes.push(archetype as unknown as Archetype<any>);
             }
             for (const quadrant of scopeQuadrants(scope)) {
                 const restored = data.entityLocationTables[quadrant];

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -1107,4 +1107,133 @@ describe("createStore", () => {
         expect(extended).toBe(store);
     });
 
+    describe("fromData sheds empty structural residue", () => {
+        const num = { type: "number", default: 0 } as const satisfies Schema;
+
+        it("does not recreate an empty archetype, nor adopt a schema no restored data uses", () => {
+            const source = createStore({ components: { a: num, ghost: num }, resources: {}, archetypes: {} });
+            const eA = source.ensureArchetype(["a"]).insert({ a: 1 });
+            // An empty archetype (created, never populated) + its schema — the exact
+            // residue a prior prune, or a since-removed feature, leaves behind.
+            source.ensureArchetype(["ghost"]);
+            const snap = source.toData({ copy: true }) as {
+                componentSchemas: Record<string, unknown>;
+                archetypesData: readonly { componentNames: readonly string[] }[];
+            };
+            // Sanity: the source snapshot really does carry the empty ghost residue.
+            expect("ghost" in snap.componentSchemas).toBe(true);
+            expect(snap.archetypesData.some((x) => x.componentNames.includes("ghost"))).toBe(true);
+
+            // Loading it (even into a store that also declares ghost) neither
+            // recreates the empty archetype nor keeps the unused schema.
+            const target = createStore({ components: { a: num }, resources: {}, archetypes: {} });
+            target.fromData(snap);
+            expect(target.read(eA)).toEqual({ a: 1 });
+            const reserialized = target.toData({ copy: true }) as {
+                componentSchemas: Record<string, unknown>;
+                archetypesData: readonly { componentNames: readonly string[] }[];
+            };
+            expect("ghost" in reserialized.componentSchemas).toBe(false);
+            expect(reserialized.archetypesData.some((x) => x.componentNames.includes("ghost"))).toBe(false);
+        });
+
+        it("preserves an unknown component that still carries data (lossless) — only empty structure is shed", () => {
+            const source = createStore({ components: { a: num, b: num }, resources: {}, archetypes: {} });
+            const e = source.ensureArchetype(["a", "b"]).insert({ a: 1, b: 2 });
+            const snap = source.toData({ copy: true });
+
+            // `target` doesn't declare `b`, but the snapshot's `b` data is populated,
+            // so it must survive the load untouched (unknown-but-populated ⇒ kept).
+            const target = createStore({ components: { a: num }, resources: {}, archetypes: {} });
+            target.fromData(snap);
+            expect(target.read(e)).toEqual({ a: 1, b: 2 });
+            const re = target.toData({ copy: true }) as { componentSchemas: Record<string, unknown> };
+            expect("b" in re.componentSchemas).toBe(true);
+        });
+
+        it("does not let a snapshot schema override the loading store's own declared schema", () => {
+            const source = createStore({
+                components: { a: { type: "number", default: 0 } as const satisfies Schema },
+                resources: {}, archetypes: {},
+            });
+            const e = source.ensureArchetype(["a"]).insert({ a: 5 });
+            const snap = source.toData({ copy: true });
+
+            const targetSchema = { type: "number", default: 99 } as const satisfies Schema;
+            const target = createStore({ components: { a: targetSchema }, resources: {}, archetypes: {} });
+            target.fromData(snap);
+            // The live schema stays the target's (default 99), not the snapshot's (0).
+            expect((target.componentSchemas as Record<string, { default?: number }>).a!.default).toBe(99);
+            // Data still restores through the declared schema.
+            expect(target.read(e)).toEqual({ a: 5 });
+        });
+    });
+
+    describe("pruneToSchema (data prune + deferred structural shed)", () => {
+        const num = { type: "number", default: 0 } as const satisfies Schema;
+
+        const makeFullStore = () =>
+            createStore({
+                components: { a: num, b: num, c: num },
+                resources: {
+                    keptRes: { default: 0 as number },
+                    foreignRes: { default: 0 as number },
+                },
+                archetypes: { AB: ["a", "b"], ABC: ["a", "b", "c"], COnly: ["c"] },
+            });
+
+        it("strips foreign component data, deletes only-foreign entities, drops foreign resources, and leaves zero foreign trace in toData", () => {
+            const store = makeFullStore();
+            const eAB = store.archetypes.AB.insert({ a: 1, b: 2 });
+            const eABC = store.archetypes.ABC.insert({ a: 3, b: 4, c: 5 });
+            const eCOnly = store.archetypes.COnly.insert({ c: 9 });
+            store.resources.keptRes = 7;
+            store.resources.foreignRes = 99;
+
+            // Keep set = the "target schema": declared components + resources.
+            store.pruneToSchema(new Set(["a", "b", "keptRes"]));
+
+            // Declared entity untouched; mixed entity keeps declared data, loses c;
+            // an entity whose every component is foreign is removed entirely.
+            expect(store.read(eAB)).toEqual({ a: 1, b: 2 });
+            expect(store.read(eABC)).toEqual({ a: 3, b: 4 });
+            expect(store.read(eCOnly)).toBeNull();
+
+            // Declared resource preserved; foreign resource gone (value + accessor).
+            expect(store.resources.keptRes).toBe(7);
+            expect((store.resources as Record<string, unknown>).foreignRes).toBeUndefined();
+
+            // The foreign entity DATA is gone immediately. The empty foreign
+            // archetypes / unused schemas may still be present as inert residue in
+            // this store's own snapshot — by design they are shed on the next load,
+            // not by an in-place structural rebuild.
+            const prunedSnap = store.toData({ copy: true });
+
+            // Loading the pruned document into a store that declares only the target
+            // schema sheds the empty foreign archetypes and unused foreign schemas:
+            // the reloaded, re-serialized document carries zero foreign trace, while
+            // entity ids and declared data survive.
+            const target = createStore({
+                components: { a: num, b: num },
+                resources: { keptRes: { default: 0 as number } },
+                archetypes: { AB: ["a", "b"] },
+            });
+            target.fromData(prunedSnap);
+            expect(target.read(eAB)).toEqual({ a: 1, b: 2 });
+            expect(target.read(eABC)).toEqual({ a: 3, b: 4 });
+            expect(target.resources.keptRes).toBe(7);
+
+            const reserialized = target.toData({ copy: true }) as {
+                componentSchemas: Record<string, unknown>;
+                archetypesData: readonly { componentNames: readonly string[] }[];
+            };
+            expect("c" in reserialized.componentSchemas).toBe(false);
+            expect("foreignRes" in reserialized.componentSchemas).toBe(false);
+            for (const arch of reserialized.archetypesData) {
+                expect(arch.componentNames).not.toContain("c");
+                expect(arch.componentNames).not.toContain("foreignRes");
+            }
+        });
+    });
+
 }); 

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -823,6 +823,38 @@ describe("createStore", () => {
             expect(v2.read(entity)).toEqual({ health: { current: 100, max: 100 } });
         });
 
+        it("remaps entities across a schema change that REMOVES an archetype (recreated by identity) and shifts surviving ids", () => {
+            // v1: three populated archetypes created in a fixed order, so their
+            // ids are a@0, x@1, b@2 — and the location table stores those ids.
+            const v1 = createStore({
+                components: { a: positionSchema, x: positionSchema, b: positionSchema },
+                resources: {},
+                archetypes: {},
+            });
+            const eA = v1.ensureArchetype(["a"]).insert({ a: { x: 1, y: 1, z: 1 } });
+            const eX = v1.ensureArchetype(["x"]).insert({ x: { x: 2, y: 2, z: 2 } });
+            const eB = v1.ensureArchetype(["b"]).insert({ b: { x: 3, y: 3, z: 3 } });
+            const snapshot = v1.toData({ copy: true });
+
+            // v2 DROPS the `x` component/archetype and pre-creates A(id0), B(id1).
+            // On load: `a` resolves to id0 (aligned); `b` (saved at pos 2) resolves
+            // to id1 — a shift; and `x`, unknown to v2 but populated in the
+            // snapshot, is recreated by identity (schema adopted from the snapshot)
+            // at id2 — another shift. The location table must remap all three.
+            const v2 = createStore({
+                components: { a: positionSchema, b: positionSchema },
+                resources: {},
+                archetypes: { A: ["a"], B: ["b"] },
+            });
+            v2.fromData(snapshot);
+
+            expect(v2.read(eA)).toEqual({ a: { x: 1, y: 1, z: 1 } });
+            expect(v2.read(eB)).toEqual({ b: { x: 3, y: 3, z: 3 } });
+            // The entity in the dropped archetype survives (unknown-but-populated),
+            // recreated by identity rather than corrupted or lost.
+            expect(v2.read(eX)).toEqual({ x: { x: 2, y: 2, z: 2 } });
+        });
+
         it("stamps a version and skips (warns, does not throw) snapshots of an incompatible or legacy format", () => {
             const store = createStore({ components: { position: positionSchema }, resources: {}, archetypes: {} });
             const entity = store.ensureArchetype(["position"]).insert({ position: { x: 1, y: 2, z: 3 } });
@@ -1232,6 +1264,32 @@ describe("createStore", () => {
             for (const arch of reserialized.archetypesData) {
                 expect(arch.componentNames).not.toContain("c");
                 expect(arch.componentNames).not.toContain("foreignRes");
+            }
+        });
+
+        it("releases the backing column memory of every archetype it empties (rowCapacity -> 0)", () => {
+            const store = makeFullStore();
+            const abc = store.archetypes.ABC; // emptied via migration (a,b kept, c stripped)
+            const cOnly = store.archetypes.COnly; // emptied via delete (all-foreign)
+            // Insert past the initial capacity of 16 so the buffers actually grew.
+            for (let i = 0; i < 20; i++) abc.insert({ a: i, b: i, c: i });
+            for (let i = 0; i < 20; i++) cOnly.insert({ c: i });
+            expect(abc.rowCapacity).toBeGreaterThanOrEqual(20);
+            expect(cOnly.rowCapacity).toBeGreaterThanOrEqual(20);
+
+            store.pruneToSchema(new Set(["a", "b", "keptRes"]));
+
+            // Both foreign archetypes linger empty in the live store (shed on next
+            // load), but must not retain their now-dead backing buffers.
+            expect(abc.rowCount).toBe(0);
+            expect(abc.rowCapacity).toBe(0);
+            for (const name of abc.components) {
+                expect(abc.columns[name as keyof typeof abc.columns]!.capacity).toBe(0);
+            }
+            expect(cOnly.rowCount).toBe(0);
+            expect(cOnly.rowCapacity).toBe(0);
+            for (const name of cOnly.components) {
+                expect(cOnly.columns[name as keyof typeof cOnly.columns]!.capacity).toBe(0);
             }
         });
     });

--- a/packages/data/src/ecs/store/public/create-store.ts
+++ b/packages/data/src/ecs/store/public/create-store.ts
@@ -259,6 +259,55 @@ export function createStore<
         return swapped;
     };
 
+    // Conform the store's DATA to a target schema (the set of component +
+    // resource names to keep). Every component not in `keep` (the ECS built-ins
+    // id/nonPersistent/nonShared are always kept) is stripped from every entity:
+    // an entity that still has a kept component migrates to its reduced
+    // archetype; an entity whose every component is foreign is removed entirely
+    // (this also removes foreign resource singletons). Index maintenance rides
+    // the normal update/delete paths.
+    //
+    // This prunes DATA only. The now-empty foreign archetypes and their (unused)
+    // component schemas are intentionally left in place — they carry nothing and
+    // are shed on the next `fromData` (which skips empty archetypes and adopts
+    // only schemas that restored data uses), so no structural rebuild / id
+    // renumber is needed here.
+    const isReservedName = (name: string): boolean =>
+        name === ID || name === "nonPersistent" || name === "nonShared";
+    const pruneToSchema = (keep: ReadonlySet<string>): void => {
+        for (const archetype of core.queryArchetypes([] as StringKeyof<C>[])) {
+            const foreign: string[] = [];
+            let hasKeptComponent = false;
+            for (const name of archetype.components) {
+                if (isReservedName(name)) continue;
+                if (keep.has(name)) hasKeptComponent = true;
+                else foreign.push(name);
+            }
+            if (foreign.length === 0) continue;
+            const idColumn = archetype.columns[ID]!;
+            if (hasKeptComponent) {
+                // Strip the foreign components, migrating each entity into its
+                // reduced, all-declared archetype. Reading row 0 each pass follows
+                // the swap-remove as rows collapse.
+                const removal = Object.fromEntries(foreign.map((n) => [n, undefined])) as any;
+                while (archetype.rowCount > 0) updateEntity(idColumn.get(0), removal);
+            } else {
+                // Nothing of this entity survives the target schema → remove it.
+                while (archetype.rowCount > 0) deleteEntity(idColumn.get(0));
+            }
+        }
+        // Retire foreign resources: the singleton entity was deleted above; drop
+        // the resource so it is neither re-initialized (reset/extend) nor read
+        // through a now-dangling accessor. Foreign component *schemas* are left in
+        // the maps so this snapshot stays internally consistent; they are shed on
+        // the next load.
+        for (const name of Object.keys(resourceSchemas)) {
+            if (keep.has(name)) continue;
+            delete (resourceSchemas as Record<string, unknown>)[name];
+            delete (resources as Record<string, unknown>)[name];
+        }
+    };
+
     const extend = (schema: Store.Schema<any, any, any>) => {
         const {
             components: schemaComponents = {},
@@ -345,6 +394,7 @@ export function createStore<
         ...core,
         update: updateEntity,
         delete: deleteEntity,
+        pruneToSchema,
         resources,
         select,
         count,

--- a/packages/data/src/ecs/store/public/create-store.ts
+++ b/packages/data/src/ecs/store/public/create-store.ts
@@ -288,13 +288,26 @@ export function createStore<
             if (hasKeptComponent) {
                 // Strip the foreign components, migrating each entity into its
                 // reduced, all-declared archetype. Reading row 0 each pass follows
-                // the swap-remove as rows collapse.
-                const removal = Object.fromEntries(foreign.map((n) => [n, undefined])) as any;
-                while (archetype.rowCount > 0) updateEntity(idColumn.get(0), removal);
+                // the swap-remove as rows collapse. A FRESH removal object per pass
+                // is required: core.update deletes the `undefined` keys from the
+                // object it is handed (to reuse it as the migrated row's data), so
+                // a shared object would empty out after the first entity and the
+                // loop would never make progress.
+                while (archetype.rowCount > 0) {
+                    const removal = Object.fromEntries(foreign.map((n) => [n, undefined])) as any;
+                    updateEntity(idColumn.get(0), removal);
+                }
             } else {
                 // Nothing of this entity survives the target schema → remove it.
                 while (archetype.rowCount > 0) deleteEntity(idColumn.get(0));
             }
+            // The archetype is now empty. It lingers (shed on the next load), so
+            // release its backing column buffers rather than retain the dead
+            // allocation. A later insert re-grows from zero on demand.
+            for (const name in archetype.columns) {
+                (archetype.columns as Record<string, { capacity: number }>)[name]!.capacity = 0;
+            }
+            archetype.rowCapacity = 0;
         }
         // Retire foreign resources: the singleton entity was deleted above; drop
         // the resource so it is neither re-initialized (reset/extend) nor read

--- a/packages/data/src/ecs/store/store.ts
+++ b/packages/data/src/ecs/store/store.ts
@@ -106,6 +106,17 @@ export interface Store<
     readonly indexes: { readonly [K in keyof IX]: Index.Handle<C, IX[K]> };
     /** Wipe all entities and reset resources to plugin defaults. O(num_archetypes + num_resources). */
     reset(): void;
+    /**
+     * Conform the store's DATA to a target schema: `keep` is the set of
+     * component + resource names to retain (the ECS built-ins are always kept).
+     * Every other component is stripped from every entity — an entity keeping at
+     * least one component migrates to its reduced archetype; an all-foreign
+     * entity (including a foreign resource singleton) is removed. Prunes data
+     * only: the emptied foreign archetypes and their unused schemas are shed on
+     * the next `fromData`, not by an in-place structural rebuild. Prefer
+     * `Database.pruneToPluginSchema` to derive `keep` from a plugin.
+     */
+    pruneToSchema(keep: ReadonlySet<string>): void;
     fromData(data: unknown, scope?: PersistenceScope): void
     extend<S extends Store.Schema>(schema: S): S extends Store.Schema<infer XC, infer XR, infer XA, infer XIX> ? Store<C & FromSchemas<XC>, R & FromSchemas<XR>, A & XA, IX & XIX, PK | PartitionKeysOf<XC>> : never;
 }


### PR DESCRIPTION
## Summary

Follow-up to #180. Addresses the observation that unknown components/archetypes round-trip opaquely through `fromData`, and adds an explicit, type-narrowing way to conform a document to a target schema.

### 1. `fromData` sheds empty structural residue (load-time)
Because the archetype-id remap from #180 makes ids position-independent, `fromData` no longer needs to recreate *every* archetype to keep ids aligned — only the **non-empty** ones (an empty archetype is referenced by no location-table entry). So `fromData` now:
- **Skips empty archetypes** (rowCount 0): nothing references their id, and recreating them just resurrects residue (e.g. a prior prune's leftovers, or a since-removed feature). A placeholder keeps the id-remap aligned by position.
- **Adopts a snapshot component schema only for components restored data actually carries**, and only when the loading store hasn't already declared it.

Net: `fromData` stays **lossless for data** (an unknown component that still carries entities is preserved) while empty structure + unused schemas fall away instead of round-tripping forever. As a bonus this fixes a latent bug where a snapshot's schema silently **overrode** the loading store's declared schema — the declared schema now wins.

### 2. `Database.pruneToPluginSchema(plugin)` (explicit, destructive)
Conforms a database's **data** to a target plugin's declared component + resource set (imports/extends already flattened at plugin creation):
- Foreign component columns are stripped from every entity (migrating it to its reduced archetype).
- An entity whose *every* component is foreign — including a foreign resource singleton — is removed.

Prunes **data only, in place**. The emptied foreign archetypes + unused schemas are left as inert residue and shed on the next `fromData` (piece 1) — so no snapshot carries them forever, with no in-place structural rebuild / id renumber. Also exposes the lower-level `store.pruneToSchema(keep)` primitive.

**Generic, type-narrowing return:** `pruneToPluginSchema<P extends Plugin>(plugin: P): Database.FromPlugin<P>` returns the same instance retyped to the target plugin's schema, so a wider database narrows to the pruned schema at the type level. Positive + negative (`@ts-expect-error`) type-tests verify it *is* assignable to `Database.FromPlugin<simplePlugin>` and is *not* assignable to `Database.FromPlugin<fullPlugin>` (and a pruned-away transaction is absent from the type).

**Memory release:** once prune empties an archetype it releases each column's `capacity` and the archetype's `rowCapacity` to 0 (swap-remove/delete drop `rowCount` but never shrink the buffers), so a lingering emptied archetype retains no dead allocation; a later insert re-grows on demand.

**No serialization format change.** Threading mirrors `extend`/`reset` across the store → transactional-store → observed-database → concurrency layers (resource-wrapper sync, observer rebuild + notify, `onReset` to clear transients).

### Scope note
Prune conforms *document data*, not plugin *behavior*: foreign named-archetype handles / transactions / systems from the original plugin remain live. The serialized document is clean; the live behavior handles linger. Call when quiescent (pending transients are cleared, as with `reset`).

## Tests
- `fromData sheds empty structural residue` — empty archetype not recreated + unused schema not adopted; unknown-but-populated component preserved (lossless); snapshot schema does not override declared schema.
- `pruneToSchema` (store) and `Database.pruneToPluginSchema` — full contract incl. the reload-shed and post-prune usability.
- **Memory release** — an emptied archetype's `rowCapacity` and column capacities go to 0.
- **Schema-change coverage (closes #180 gap)** — an archetype the new schema *removes* is recreated by identity and surviving ids shift; the location table remaps all entities (complements the existing add-ahead case).
- **Type-tests** (`database.prune.type-test.ts`) — positive/negative assignability of the narrowed return type.

## Notable bug found while testing
The memory-release test (which inserts enough entities to force buffer growth) surfaced an **infinite loop** in `pruneToSchema`: `core.update` deletes the `undefined` keys from the values object it's handed (reusing it as the migrated row's data), so a single shared `removal` object emptied out after the first entity and the migration loop never progressed for any foreign archetype with 2+ entities. Fixed by building a fresh `removal` object per entity.

Full suites pass: **3071** data + **240** persistence tests; monorepo lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)