### PR TITLE
feat(data): Schema.createCoerceFunction + convertTypedBuffer

### DIFF
--- a/packages/data/src/ecs/archetype/coerce-archetype-column.ts
+++ b/packages/data/src/ecs/archetype/coerce-archetype-column.ts
@@ -25,7 +25,7 @@ export function coerceArchetypeColumn(
     const columns = archetype.columns as Record<string, TypedBuffer<unknown>>;
     const existing = columns[component];
     if (existing === undefined) return false;
-    const converted = convertTypedBuffer(existing, targetSchema, archetype.rowCapacity, archetype.rowCount);
+    const converted = convertTypedBuffer(existing, targetSchema, { capacity: archetype.rowCapacity, count: archetype.rowCount });
     archetype.fromData({
         columns: { ...columns, [component]: converted },
         rowCount: archetype.rowCount,

--- a/packages/data/src/ecs/archetype/coerce-archetype-column.ts
+++ b/packages/data/src/ecs/archetype/coerce-archetype-column.ts
@@ -1,0 +1,35 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import type { Schema } from "../../schema/index.js";
+import { TypedBuffer, convertTypedBuffer } from "../../typed-buffer/index.js";
+import type { Archetype } from "./archetype.js";
+
+/**
+ * Convert one component column of `archetype` to `targetSchema` IN PLACE,
+ * preserving the archetype's live rows. Returns `false` (a no-op) when the
+ * component is absent from this archetype.
+ *
+ * An archetype (a table) bakes its column references into a specialized `insert`;
+ * swapping a column therefore goes through `archetype.fromData`, which replaces
+ * the columns AND rebuilds that baked insert so later inserts write through the
+ * converted column. Only the live `rowCount` rows are converted — unused capacity
+ * stays at the new column's default.
+ *
+ * Throws (via {@link convertTypedBuffer}) if no automatic conversion exists.
+ */
+export function coerceArchetypeColumn(
+    archetype: Archetype<any>,
+    component: string,
+    targetSchema: Schema,
+): boolean {
+    const columns = archetype.columns as Record<string, TypedBuffer<unknown>>;
+    const existing = columns[component];
+    if (existing === undefined) return false;
+    const converted = convertTypedBuffer(existing, targetSchema, archetype.rowCapacity, archetype.rowCount);
+    archetype.fromData({
+        columns: { ...columns, [component]: converted },
+        rowCount: archetype.rowCount,
+        rowCapacity: archetype.rowCapacity,
+    });
+    return true;
+}

--- a/packages/data/src/ecs/archetype/coerce-archetype-column.ts
+++ b/packages/data/src/ecs/archetype/coerce-archetype-column.ts
@@ -25,7 +25,7 @@ export function coerceArchetypeColumn(
     const columns = archetype.columns as Record<string, TypedBuffer<unknown>>;
     const existing = columns[component];
     if (existing === undefined) return false;
-    const converted = convertTypedBuffer(existing, targetSchema, { capacity: archetype.rowCapacity, count: archetype.rowCount });
+    const converted = convertTypedBuffer({ source: existing, targetSchema, capacity: archetype.rowCapacity, count: archetype.rowCount });
     archetype.fromData({
         columns: { ...columns, [component]: converted },
         rowCount: archetype.rowCount,

--- a/packages/data/src/ecs/archetype/index.ts
+++ b/packages/data/src/ecs/archetype/index.ts
@@ -2,3 +2,4 @@
 export * from "./archetype.js";
 export * from "./create-archetype.js";
 export * from "./delete-row.js";
+export * from "./coerce-archetype-column.js";

--- a/packages/data/src/ecs/store/coerce-store-component.test.ts
+++ b/packages/data/src/ecs/store/coerce-store-component.test.ts
@@ -1,0 +1,78 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { describe, it, expect } from "vitest";
+import { Store } from "./index.js";
+import { coerceStoreComponent } from "./coerce-store-component.js";
+import { coerceArchetypeColumn, type Archetype } from "../archetype/index.js";
+import type { Schema } from "../../schema/index.js";
+
+const f32 = { type: "number", precision: 1 } as const satisfies Schema;
+const num = { type: "number" } as const satisfies Schema;
+const vec2 = { type: "object", properties: { x: f32, y: f32 } } as const satisfies Schema;
+const vec3 = { type: "object", properties: { x: f32, y: f32, z: { type: "number", precision: 1, default: 7 } } } as const satisfies Schema;
+const capped = { type: "integer", minimum: 0, maximum: 100 } as const satisfies Schema;
+
+describe("coerceArchetypeColumn — in-place column conversion on a table", () => {
+    it("adds a struct field to every live row and keeps insert working", () => {
+        const store = Store.create({ components: { pos: vec2 }, resources: {}, archetypes: { P: ["pos"] } });
+        const P = store.archetypes.P as any;
+        const e0 = P.insert({ pos: { x: 1, y: 2 } });
+        const e1 = P.insert({ pos: { x: 3, y: 4 } });
+
+        const arch = store.queryArchetypes(["pos"])[0] as unknown as Archetype<any>;
+        expect(coerceArchetypeColumn(arch, "pos", vec3)).toBe(true);
+
+        // Existing rows carry the new field's default.
+        expect(store.read(e0)).toEqual({ pos: { x: 1, y: 2, z: 7 } });
+        expect(store.read(e1)).toEqual({ pos: { x: 3, y: 4, z: 7 } });
+        // The column now reports the new schema.
+        expect(arch.columns.pos.schema).toBe(vec3);
+
+        // Insert AFTER the swap writes through the rebuilt (converted) column.
+        const e2 = P.insert({ pos: { x: 5, y: 6, z: 8 } });
+        expect(store.read(e2)).toEqual({ pos: { x: 5, y: 6, z: 8 } });
+    });
+
+    it("is a no-op returning false when the component is absent", () => {
+        const store = Store.create({ components: { pos: vec2 }, resources: {}, archetypes: { P: ["pos"] } });
+        const p = store.queryArchetypes(["pos"])[0] as unknown as Archetype<any>;
+        expect(coerceArchetypeColumn(p, "missing", num)).toBe(false);
+    });
+});
+
+describe("coerceStoreComponent — in-place schema change across the whole store", () => {
+    it("converts the component in every archetype and adopts the new schema", () => {
+        const store = Store.create({
+            components: { hp: num, mana: num },
+            resources: {},
+            archetypes: { A: ["hp"], AB: ["hp", "mana"] },
+        });
+        const A = store.archetypes.A as any;
+        const AB = store.archetypes.AB as any;
+        const e0 = A.insert({ hp: 50 });
+        const e1 = A.insert({ hp: 70000 });
+        const e2 = AB.insert({ hp: 90000, mana: 5 });
+
+        coerceStoreComponent(store, "hp", capped);
+
+        // Every archetype's existing rows are clamped into the new range.
+        expect(store.read(e0)).toEqual({ hp: 50 });
+        expect(store.read(e1)).toEqual({ hp: 100 });
+        expect(store.read(e2)).toEqual({ hp: 100, mana: 5 });
+
+        // The store adopts the new schema; the untouched component is unchanged.
+        expect((store.componentSchemas as Record<string, Schema>).hp).toBe(capped);
+        expect((store.componentSchemas as Record<string, Schema>).mana).toBe(num);
+
+        // Inserts now go through the new (integer-backed) storage: a fractional
+        // value truncates, proving the column was actually re-typed.
+        const e3 = A.insert({ hp: 42.9 });
+        expect(store.read(e3)).toEqual({ hp: 42 });
+    });
+
+    it("throws when a column cannot be automatically converted", () => {
+        const store = Store.create({ components: { hp: num }, resources: {}, archetypes: { A: ["hp"] } });
+        (store.archetypes.A as any).insert({ hp: 1 });
+        expect(() => coerceStoreComponent(store, "hp", vec2)).toThrow(/No automatic TypedBuffer conversion/);
+    });
+});

--- a/packages/data/src/ecs/store/coerce-store-component.ts
+++ b/packages/data/src/ecs/store/coerce-store-component.ts
@@ -1,0 +1,36 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import type { Schema } from "../../schema/index.js";
+import type { Archetype, ReadonlyArchetype } from "../archetype/index.js";
+import { coerceArchetypeColumn } from "../archetype/index.js";
+
+// The minimal store surface this helper needs. Declared structurally (with `any`
+// in the query signature) so a concretely-typed store assigns without the
+// generic-method variance that blocks assignment to `ReadonlyStore<any,…>`.
+interface CoercibleStore {
+    queryArchetypes(include: readonly any[], options?: any): readonly ReadonlyArchetype<any>[];
+    readonly componentSchemas: object;
+}
+
+/**
+ * Change a component's schema across the whole store IN PLACE: convert that
+ * component's column in every archetype that carries it, then adopt
+ * `targetSchema` as the component's declared schema so subsequently-created
+ * archetypes back it the new way.
+ *
+ * This is the store-level counterpart to {@link coerceArchetypeColumn}, and the
+ * building block for migrating a persisted schema forward without a full reload.
+ * Throws if any archetype's column has no automatic conversion to `targetSchema`.
+ */
+export function coerceStoreComponent(
+    store: CoercibleStore,
+    component: string,
+    targetSchema: Schema,
+): void {
+    // queryArchetypes returns ReadonlyArchetype, but these are the live Archetype
+    // instances that carry the fromData/insert surface the column swap needs.
+    for (const archetype of store.queryArchetypes([component])) {
+        coerceArchetypeColumn(archetype as unknown as Archetype<any>, component, targetSchema);
+    }
+    (store.componentSchemas as Record<string, Schema>)[component] = targetSchema;
+}

--- a/packages/data/src/ecs/store/index.ts
+++ b/packages/data/src/ecs/store/index.ts
@@ -1,5 +1,6 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 export * from "./store.js";
+export * from "./coerce-store-component.js";
 export * from "./archetype-components.js";
 export type { ArchetypeSchema, ArchetypeRowOf, ArchetypeHandleOf } from "./archetype-row.js";
 export type { EntityReadValues, EntityUpdateValues, ArchetypeQueryOptions } from "./core/core.js";

--- a/packages/data/src/schema/create-coerce-function.test.ts
+++ b/packages/data/src/schema/create-coerce-function.test.ts
@@ -76,10 +76,29 @@ describe("createCoerceFunction — objects", () => {
         expect(fn({ x: 1, y: 2 })).toEqual({ x: 1, y: 2, z: 9 });
     });
 
-    it("is not convertible when a new field has no default", () => {
+    it("requires a default for a new field of a numeric STRUCT (every field is packed)", () => {
+        // f32 properties pack as a struct → a missing field would be NaN, so a
+        // new field without a default makes the conversion impossible.
         expect(createCoerceFunction(
             { type: "object", properties: { x: f32 } },
             { type: "object", properties: { x: f32, z: f32 } },
+        )).toBeNull();
+    });
+
+    it("omits a new NON-required field with no default on a plain object", () => {
+        // f64 properties do not pack as a struct → a plain object may simply lack
+        // an optional field, so this is convertible and the field is left off.
+        const fn = coercer(
+            { type: "object", properties: { a: num } },
+            { type: "object", properties: { a: num, b: num } },
+        );
+        expect(fn({ a: 1 })).toEqual({ a: 1 });
+    });
+
+    it("still requires a default for a new REQUIRED field on a plain object", () => {
+        expect(createCoerceFunction(
+            { type: "object", properties: { a: num } },
+            { type: "object", properties: { a: num, b: num }, required: ["b"] },
         )).toBeNull();
     });
 
@@ -111,9 +130,11 @@ describe("createCoerceFunction — objects", () => {
     });
 
     it("is not convertible when an existing sub-field cannot be converted", () => {
+        // Nested numeric struct gains a defaultless field ⇒ the sub-conversion,
+        // and therefore the whole conversion, is impossible.
         expect(createCoerceFunction(
-            { type: "object", properties: { p: { type: "object", properties: { a: num } } } },
-            { type: "object", properties: { p: { type: "object", properties: { a: num, b: f32 } } } },
+            { type: "object", properties: { p: { type: "object", properties: { x: f32 } } } },
+            { type: "object", properties: { p: { type: "object", properties: { x: f32, y: f32 } } } },
         )).toBeNull();
     });
 });

--- a/packages/data/src/schema/create-coerce-function.test.ts
+++ b/packages/data/src/schema/create-coerce-function.test.ts
@@ -1,0 +1,171 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { describe, it, expect } from "vitest";
+import { createCoerceFunction } from "./create-coerce-function.js";
+import { Schema } from "./index.js";
+import type { Schema as SchemaType } from "./schema.js";
+
+const num = { type: "number" } as const satisfies SchemaType;
+const f32 = { type: "number", precision: 1 } as const satisfies SchemaType;
+const bool = { type: "boolean" } as const satisfies SchemaType;
+const str = { type: "string" } as const satisfies SchemaType;
+
+// createCoerceFunction never returns null in the "possible" cases — narrow it.
+const coercer = (input: SchemaType, output: SchemaType) => {
+    const fn = createCoerceFunction(input, output);
+    expect(fn).not.toBeNull();
+    return fn!;
+};
+
+describe("createCoerceFunction — numbers", () => {
+    it("number → number with no bounds is identity (F64→F32 precision loss is the buffer's job)", () => {
+        const fn = coercer(num, f32);
+        expect(fn(3.14159)).toBe(3.14159);
+        expect(fn(-100)).toBe(-100);
+    });
+
+    it("clamps to the output maximum / minimum when declared", () => {
+        expect(coercer(num, { type: "number", maximum: 100 })(150)).toBe(100);
+        expect(coercer(num, { type: "number", maximum: 100 })(50)).toBe(50);
+        expect(coercer(num, { type: "number", minimum: 0 })(-5)).toBe(0);
+        const both = coercer(num, { type: "number", minimum: 0, maximum: 10 });
+        expect([both(-1), both(5), both(99)]).toEqual([0, 5, 10]);
+    });
+
+    it("caps a wide integer down to a narrow integer range (the U32→'U16' case)", () => {
+        const fn = coercer({ type: "integer" }, { type: "integer", minimum: 0, maximum: 65535 });
+        expect(fn(70000)).toBe(65535);
+        expect(fn(-5)).toBe(0);
+        expect(fn(40000)).toBe(40000);
+    });
+});
+
+describe("createCoerceFunction — scalars & enums", () => {
+    it("boolean → boolean and string → string are identity", () => {
+        expect(coercer(bool, bool)(true)).toBe(true);
+        expect(coercer(str, str)("hi")).toBe("hi");
+    });
+
+    it("enum → enum only when every input value is an output value", () => {
+        const widen = coercer({ enum: ["a", "b"] }, { enum: ["a", "b", "c"] });
+        expect(widen("a")).toBe("a");
+        expect(createCoerceFunction({ enum: ["a", "z"] }, { enum: ["a", "b"] })).toBeNull();
+    });
+
+    it("→ const collapses any input to the constant", () => {
+        const fn = coercer(num, { const: 42 });
+        expect(fn(1)).toBe(42);
+        expect(fn(999)).toBe(42);
+    });
+});
+
+describe("createCoerceFunction — objects", () => {
+    it("reorders fields (order is irrelevant to the produced value)", () => {
+        const fn = coercer(
+            { type: "object", properties: { x: f32, y: f32 } },
+            { type: "object", properties: { y: f32, x: f32 } },
+        );
+        expect(fn({ x: 1, y: 2 })).toEqual({ x: 1, y: 2 });
+    });
+
+    it("fills a new field from its default", () => {
+        const fn = coercer(
+            { type: "object", properties: { x: f32, y: f32 } },
+            { type: "object", properties: { x: f32, y: f32, z: { type: "number", default: 9 } } },
+        );
+        expect(fn({ x: 1, y: 2 })).toEqual({ x: 1, y: 2, z: 9 });
+    });
+
+    it("is not convertible when a new field has no default", () => {
+        expect(createCoerceFunction(
+            { type: "object", properties: { x: f32 } },
+            { type: "object", properties: { x: f32, z: f32 } },
+        )).toBeNull();
+    });
+
+    it("drops fields the output does not declare", () => {
+        const fn = coercer(
+            { type: "object", properties: { x: f32, y: f32, z: f32 } },
+            { type: "object", properties: { x: f32, y: f32 } },
+        );
+        expect(fn({ x: 1, y: 2, z: 3 })).toEqual({ x: 1, y: 2 });
+    });
+
+    it("coerces (and clamps) a retyped field", () => {
+        const fn = coercer(
+            { type: "object", properties: { x: num } },
+            { type: "object", properties: { x: { type: "integer", minimum: 0, maximum: 10 } } },
+        );
+        expect(fn({ x: 50 })).toEqual({ x: 10 });
+    });
+
+    it("gives each element its own copy of an object default (no aliasing)", () => {
+        const fn = coercer(
+            { type: "object", properties: { x: f32 } },
+            { type: "object", properties: { x: f32, meta: { type: "object", properties: { n: { type: "number", default: 0 } } } } },
+        );
+        const a = fn({ x: 1 }) as { meta: object };
+        const b = fn({ x: 2 }) as { meta: object };
+        expect(a.meta).toEqual({ n: 0 });
+        expect(a.meta).not.toBe(b.meta); // distinct instances
+    });
+
+    it("is not convertible when an existing sub-field cannot be converted", () => {
+        expect(createCoerceFunction(
+            { type: "object", properties: { p: { type: "object", properties: { a: num } } } },
+            { type: "object", properties: { p: { type: "object", properties: { a: num, b: f32 } } } },
+        )).toBeNull();
+    });
+});
+
+describe("createCoerceFunction — arrays", () => {
+    it("extends a fixed vector, filling from the item default (vec3 → vec4)", () => {
+        const fn = coercer(
+            { type: "array", items: f32, minItems: 3, maxItems: 3 },
+            { type: "array", items: { type: "number", default: 0 }, minItems: 4, maxItems: 4 },
+        );
+        expect(fn([1, 2, 3])).toEqual([1, 2, 3, 0]);
+    });
+
+    it("is not convertible when a longer fixed output has no item default", () => {
+        expect(createCoerceFunction(
+            { type: "array", items: f32, minItems: 3, maxItems: 3 },
+            { type: "array", items: f32, minItems: 4, maxItems: 4 },
+        )).toBeNull();
+    });
+
+    it("truncates a fixed vector (vec3 → vec2)", () => {
+        const fn = coercer(
+            { type: "array", items: f32, minItems: 3, maxItems: 3 },
+            { type: "array", items: f32, minItems: 2, maxItems: 2 },
+        );
+        expect(fn([1, 2, 3])).toEqual([1, 2]);
+    });
+
+    it("maps every element of a variable-length array (with clamp)", () => {
+        const fn = coercer(
+            { type: "array", items: num },
+            { type: "array", items: { type: "integer", minimum: 0, maximum: 5 } },
+        );
+        expect(fn([1, 10, 3])).toEqual([1, 5, 3]);
+    });
+});
+
+describe("createCoerceFunction — incompatible kinds return null", () => {
+    it.each([
+        ["number → object", num, { type: "object", properties: { x: f32 } } as SchemaType],
+        ["object → number", { type: "object", properties: { x: f32 } } as SchemaType, num],
+        ["number → boolean", num, bool],
+        ["number → enum", num, { enum: [1, 2, 3] } as SchemaType],
+        ["array → object", { type: "array", items: num } as SchemaType, { type: "object", properties: { x: f32 } } as SchemaType],
+    ])("%s", (_label, input, output) => {
+        expect(createCoerceFunction(input, output)).toBeNull();
+    });
+});
+
+describe("createCoerceFunction — namespace exposure", () => {
+    it("is reachable as Schema.createCoerceFunction", () => {
+        expect(typeof Schema.createCoerceFunction).toBe("function");
+        expect(Schema.createCoerceFunction(num, f32)!(1.5)).toBe(1.5);
+    });
+});

--- a/packages/data/src/schema/create-coerce-function.ts
+++ b/packages/data/src/schema/create-coerce-function.ts
@@ -1,6 +1,7 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 
 import { Schema } from "./schema.js";
+import { getStructLayout } from "../typed-buffer/structs/get-struct-layout.js";
 
 /**
  * Build a reusable value converter from an `input` schema to an `output` schema,
@@ -130,8 +131,14 @@ function objectCoercer(
 ): null | ((value: unknown) => unknown) {
     const outProps = output.properties ?? {};
     const inProps = input.properties ?? {};
-    // Precompute, per output property, how to produce its value: either coerce
-    // the matching input property or supply a fixed default for a new property.
+    // A numeric struct packs EVERY property into fixed storage — a missing field
+    // reads as NaN — so all of its fields are effectively required. A plain
+    // object may legitimately lack a non-required property.
+    const packsAsStruct = getStructLayout(output, false) !== null;
+    const required = new Set(output.required ?? []);
+    // Precompute, per PRODUCED output property, how to build its value: either
+    // coerce the matching input property or supply a fixed default. A new
+    // non-required plain-object field with no default is simply not produced.
     const fields: [key: string, produce: (source: Record<string, unknown>) => unknown][] = [];
     for (const key of Object.keys(outProps)) {
         const outSchema = outProps[key]!;
@@ -140,11 +147,15 @@ function objectCoercer(
             const sub = createCoerceFunction(inSchema, outSchema);
             if (sub === null) return null; // an existing field cannot be converted
             fields.push([key, (source) => sub(source[key])]);
-        } else {
-            const def = defaultValue(outSchema);
-            if (def === NO_DEFAULT) return null; // new field with no default ⇒ not convertible
-            fields.push([key, () => cloneDefault(def)]);
+            continue;
         }
+        const def = defaultValue(outSchema);
+        if (def !== NO_DEFAULT) {
+            fields.push([key, () => cloneDefault(def)]);
+        } else if (packsAsStruct || required.has(key)) {
+            return null; // a mandatory new field with no default ⇒ not convertible
+        }
+        // else: optional plain-object field, no default ⇒ omit it entirely.
     }
     return (value) => {
         const source = value as Record<string, unknown>;

--- a/packages/data/src/schema/create-coerce-function.ts
+++ b/packages/data/src/schema/create-coerce-function.ts
@@ -1,0 +1,231 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { Schema } from "./schema.js";
+
+/**
+ * Build a reusable value converter from an `input` schema to an `output` schema,
+ * or return `null` when no automatic conversion exists.
+ *
+ * The analysis is done ONCE, here; the returned function is a specialized closure
+ * meant to be applied to every element of a homogeneous collection (e.g. a
+ * TypedBuffer column) without re-inspecting the schemas per element. A `null`
+ * return IS the "not convertible" answer — there is no separate predicate.
+ *
+ * Supported automatic conversions:
+ *   - **number/integer → number/integer**: pass-through; when the output declares
+ *     `minimum`/`maximum`, values are clamped into range (so a narrowing like a
+ *     capped integer keeps its cap). Precision/width loss (F64→F32, float→int) is
+ *     applied by the destination buffer's typed-array write, not here.
+ *   - **boolean → boolean**, **string → string**: identity.
+ *   - **enum → enum**: only when every input value is also an output value.
+ *   - **→ const**: any input, every element becomes the output's const value.
+ *   - **object → object**: per output property, convert the matching input
+ *     property, or fill from the output property's default when the input lacks
+ *     it. A new output property with no producible default ⇒ not convertible
+ *     (`null`). Input-only properties are dropped; property order is irrelevant.
+ *   - **array → array**: element-wise via `items`; a fixed-length output longer
+ *     than a fixed-length input fills the extra slots from the item default (or
+ *     is not convertible without one).
+ *
+ * Anything else — a change of kind (number↔object, number↔enum, …) — returns
+ * `null`. Cosmetic schema differences are irrelevant; only the value shape is.
+ */
+export function createCoerceFunction(
+    input: Schema,
+    output: Schema,
+): null | ((value: unknown) => unknown) {
+    // Any input collapses to the output's fixed value.
+    if (output.const !== undefined) {
+        const constValue = output.const;
+        return () => constValue;
+    }
+
+    const outKind = kindOf(output);
+    const inKind = kindOf(input);
+
+    switch (outKind) {
+        case "number": {
+            if (inKind !== "number") return null;
+            return numberCoercer(output);
+        }
+        case "boolean":
+            return inKind === "boolean" ? identity : null;
+        case "string":
+            return inKind === "string" ? identity : null;
+        case "enum": {
+            const allowed = new Set(output.enum);
+            if (input.enum && input.enum.every((v) => allowed.has(v))) return identity;
+            if (input.const !== undefined && allowed.has(input.const)) return identity;
+            return null;
+        }
+        case "object": {
+            if (inKind !== "object") return null;
+            return objectCoercer(input, output);
+        }
+        case "array": {
+            if (inKind !== "array") return null;
+            return arrayCoercer(input, output);
+        }
+        default:
+            return null;
+    }
+}
+
+type Kind = "number" | "boolean" | "string" | "object" | "array" | "enum" | "unknown";
+
+// The value-shape category a schema describes. Storage kind (struct vs array
+// buffer) is irrelevant — coercion is value-shaped. A bare `const`/`enum` schema
+// (no explicit type) is categorized from its value(s).
+function kindOf(schema: Schema): Kind {
+    if (schema.enum && schema.enum.length > 0) return "enum";
+    switch (schema.type) {
+        case "number":
+        case "integer":
+            return "number";
+        case "boolean":
+            return "boolean";
+        case "string":
+            return "string";
+        case "object":
+            return "object";
+        case "array":
+            return "array";
+    }
+    if (schema.const !== undefined) return kindOfValue(schema.const);
+    return "unknown";
+}
+
+function kindOfValue(value: unknown): Kind {
+    switch (typeof value) {
+        case "number":
+            return "number";
+        case "boolean":
+            return "boolean";
+        case "string":
+            return "string";
+        case "object":
+            return value === null ? "unknown" : Array.isArray(value) ? "array" : "object";
+        default:
+            return "unknown";
+    }
+}
+
+const identity = (value: unknown): unknown => value;
+
+function numberCoercer(output: Schema): (value: unknown) => unknown {
+    const hasMin = output.minimum !== undefined;
+    const hasMax = output.maximum !== undefined;
+    if (!hasMin && !hasMax) return identity;
+    const min = output.minimum ?? -Infinity;
+    const max = output.maximum ?? Infinity;
+    return (value) => {
+        const n = value as number;
+        return n < min ? min : n > max ? max : n;
+    };
+}
+
+function objectCoercer(
+    input: Schema,
+    output: Schema,
+): null | ((value: unknown) => unknown) {
+    const outProps = output.properties ?? {};
+    const inProps = input.properties ?? {};
+    // Precompute, per output property, how to produce its value: either coerce
+    // the matching input property or supply a fixed default for a new property.
+    const fields: [key: string, produce: (source: Record<string, unknown>) => unknown][] = [];
+    for (const key of Object.keys(outProps)) {
+        const outSchema = outProps[key]!;
+        const inSchema = inProps[key];
+        if (inSchema !== undefined) {
+            const sub = createCoerceFunction(inSchema, outSchema);
+            if (sub === null) return null; // an existing field cannot be converted
+            fields.push([key, (source) => sub(source[key])]);
+        } else {
+            const def = defaultValue(outSchema);
+            if (def === NO_DEFAULT) return null; // new field with no default ⇒ not convertible
+            fields.push([key, () => cloneDefault(def)]);
+        }
+    }
+    return (value) => {
+        const source = value as Record<string, unknown>;
+        const result: Record<string, unknown> = {};
+        for (const [key, produce] of fields) result[key] = produce(source);
+        return result;
+    };
+}
+
+function arrayCoercer(
+    input: Schema,
+    output: Schema,
+): null | ((value: unknown) => unknown) {
+    const outItems = output.items;
+    const inItems = input.items;
+    if (!outItems || !inItems) return null;
+    const elem = createCoerceFunction(inItems, outItems);
+    if (elem === null) return null;
+
+    const outFixed = fixedLength(output);
+    if (outFixed === undefined) {
+        // Variable-length output: map every input element.
+        return (value) => (value as unknown[]).map(elem);
+    }
+    // Fixed-length output. If a fixed-length input is shorter, the extra slots
+    // need an item default; without one the conversion is not possible.
+    const inFixed = fixedLength(input);
+    const def = defaultValue(outItems);
+    if (inFixed !== undefined && inFixed < outFixed && def === NO_DEFAULT) return null;
+    return (value) => {
+        const arr = value as unknown[];
+        const result = new Array<unknown>(outFixed);
+        for (let i = 0; i < outFixed; i++) {
+            result[i] = i < arr.length ? elem(arr[i]) : cloneDefault(def);
+        }
+        return result;
+    };
+}
+
+function fixedLength(schema: Schema): number | undefined {
+    return schema.minItems !== undefined && schema.minItems === schema.maxItems
+        ? schema.minItems
+        : undefined;
+}
+
+// A sentinel distinct from `undefined`, which is itself a legitimate default.
+const NO_DEFAULT = Symbol("no-default");
+
+// The default value a schema produces, or NO_DEFAULT when none can be built.
+// An explicit `default`/`const` wins; an object/fixed-array is buildable only
+// when every one of its parts has a producible default (recursively).
+function defaultValue(schema: Schema): unknown {
+    if (schema.default !== undefined) return schema.default;
+    if (schema.const !== undefined) return schema.const;
+    switch (kindOf(schema)) {
+        case "object": {
+            const props = schema.properties ?? {};
+            const result: Record<string, unknown> = {};
+            for (const key of Object.keys(props)) {
+                const def = defaultValue(props[key]!);
+                if (def === NO_DEFAULT) return NO_DEFAULT;
+                result[key] = def;
+            }
+            return result;
+        }
+        case "array": {
+            const length = fixedLength(schema);
+            if (length === undefined || !schema.items) return NO_DEFAULT;
+            const def = defaultValue(schema.items);
+            if (def === NO_DEFAULT) return NO_DEFAULT;
+            return Array.from({ length }, () => cloneDefault(def));
+        }
+        default:
+            return NO_DEFAULT;
+    }
+}
+
+// Defaults seed NEW fields (they are not source data), so give each element its
+// own copy of an object/array default rather than aliasing one instance across
+// every row. Primitives are shared as-is.
+function cloneDefault(def: unknown): unknown {
+    if (def === null || typeof def !== "object") return def;
+    return structuredClone(def);
+}

--- a/packages/data/src/schema/public.ts
+++ b/packages/data/src/schema/public.ts
@@ -7,4 +7,5 @@ export * from "./to-type.js";
 export * from "./from-object-properties.js";
 export * from "./from-archetype.js";
 export * from "./from-struct-properties.js";
+export * from "./create-coerce-function.js";
 

--- a/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
@@ -1,0 +1,110 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { describe, it, expect } from "vitest";
+import { createTypedBuffer } from "./create-typed-buffer.js";
+import { convertTypedBuffer } from "./convert-typed-buffer.js";
+import type { Schema } from "../schema/schema.js";
+
+const num = { type: "number" } as const satisfies Schema;
+const f32 = { type: "number", precision: 1 } as const satisfies Schema;
+
+describe("convertTypedBuffer — numeric buffers", () => {
+    it("F64 → F32 copies with precision loss", () => {
+        const src = createTypedBuffer(num, 2);
+        src.set(0, 0.1);
+        src.set(1, 1.5);
+        const out = convertTypedBuffer(src, f32, 2);
+        // 1.5 is exact in f32; 0.1 rounds to the nearest f32.
+        expect(out.get(1)).toBe(1.5);
+        expect(out.get(0)).toBe(new Float32Array([0.1])[0]);
+        expect(out.get(0)).not.toBe(0.1);
+    });
+
+    it("caps values into a narrow integer range on convert", () => {
+        const src = createTypedBuffer(num, 3);
+        src.set(0, 50);
+        src.set(1, 70000);
+        src.set(2, -5);
+        const capped = { type: "integer", minimum: 0, maximum: 100 } as const satisfies Schema;
+        const out = convertTypedBuffer(src, capped, 3);
+        expect([out.get(0), out.get(1), out.get(2)]).toEqual([50, 100, 0]);
+    });
+});
+
+describe("convertTypedBuffer — struct (value-type) buffers", () => {
+    const vec2 = { type: "object", properties: { x: f32, y: f32 } } as const satisfies Schema;
+
+    it("the source is actually a struct buffer (sanity)", () => {
+        expect(createTypedBuffer(vec2, 1).type).toBe("struct");
+    });
+
+    it("reorders struct fields", () => {
+        const src = createTypedBuffer(vec2, 1);
+        src.set(0, { x: 1, y: 2 });
+        const reordered = { type: "object", properties: { y: f32, x: f32 } } as const satisfies Schema;
+        const out = convertTypedBuffer(src, reordered, 1);
+        expect(out.get(0)).toEqual({ x: 1, y: 2 });
+    });
+
+    it("adds a struct field from its default", () => {
+        const src = createTypedBuffer(vec2, 1);
+        src.set(0, { x: 1, y: 2 });
+        const vec3 = { type: "object", properties: { x: f32, y: f32, z: { type: "number", precision: 1, default: 7 } } } as const satisfies Schema;
+        const out = convertTypedBuffer(src, vec3, 1);
+        expect(out.get(0)).toEqual({ x: 1, y: 2, z: 7 });
+    });
+
+    it("clamps a struct field on convert", () => {
+        const src = createTypedBuffer(vec2, 1);
+        src.set(0, { x: 50, y: 3 });
+        const clamped = { type: "object", properties: { x: { type: "number", precision: 1, maximum: 10 }, y: f32 } } as const satisfies Schema;
+        const out = convertTypedBuffer(src, clamped, 1);
+        expect(out.get(0)).toEqual({ x: 10, y: 3 });
+    });
+});
+
+describe("convertTypedBuffer — array (object-holding) buffers", () => {
+    // f64 object properties do NOT pack as a struct → these are array buffers.
+    const ab = { type: "object", properties: { a: num, b: num } } as const satisfies Schema;
+
+    it("the source is actually an array buffer (sanity)", () => {
+        expect(createTypedBuffer(ab, 1).type).toBe("array");
+    });
+
+    it("adds a field from its default across every element", () => {
+        const src = createTypedBuffer(ab, 2);
+        src.set(0, { a: 1, b: 2 });
+        src.set(1, { a: 3, b: 4 });
+        const abc = { type: "object", properties: { a: num, b: num, c: { type: "number", default: 5 } } } as const satisfies Schema;
+        const out = convertTypedBuffer(src, abc, 2);
+        expect(out.get(0)).toEqual({ a: 1, b: 2, c: 5 });
+        expect(out.get(1)).toEqual({ a: 3, b: 4, c: 5 });
+    });
+
+    it("drops a field the target does not declare", () => {
+        const src = createTypedBuffer(ab, 1);
+        src.set(0, { a: 1, b: 2 });
+        const justA = { type: "object", properties: { a: num } } as const satisfies Schema;
+        const out = convertTypedBuffer(src, justA, 1);
+        expect(out.get(0)).toEqual({ a: 1 });
+    });
+});
+
+describe("convertTypedBuffer — enum & const", () => {
+    it("widens an enum buffer", () => {
+        const src = createTypedBuffer({ enum: ["a", "b"], default: "a" }, 2);
+        src.set(0, "a");
+        src.set(1, "b");
+        const out = convertTypedBuffer(src, { enum: ["a", "b", "c"], default: "a" }, 2);
+        expect([out.get(0), out.get(1)]).toEqual(["a", "b"]);
+    });
+});
+
+describe("convertTypedBuffer — not convertible", () => {
+    it("throws when no automatic conversion exists", () => {
+        const src = createTypedBuffer(num, 1);
+        expect(() => convertTypedBuffer(src, { type: "object", properties: { x: f32 } }, 1)).toThrow(
+            /No automatic TypedBuffer conversion/,
+        );
+    });
+});

--- a/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
@@ -13,7 +13,7 @@ describe("convertTypedBuffer — numeric buffers", () => {
         const src = createTypedBuffer(num, 2);
         src.set(0, 0.1);
         src.set(1, 1.5);
-        const out = convertTypedBuffer(src, f32);
+        const out = convertTypedBuffer({ source: src, targetSchema: f32 });
         // 1.5 is exact in f32; 0.1 rounds to the nearest f32.
         expect(out.get(1)).toBe(1.5);
         expect(out.get(0)).toBe(new Float32Array([0.1])[0]);
@@ -26,7 +26,7 @@ describe("convertTypedBuffer — numeric buffers", () => {
         src.set(1, 70000);
         src.set(2, -5);
         const capped = { type: "integer", minimum: 0, maximum: 100 } as const satisfies Schema;
-        const out = convertTypedBuffer(src, capped);
+        const out = convertTypedBuffer({ source: src, targetSchema: capped });
         expect([out.get(0), out.get(1), out.get(2)]).toEqual([50, 100, 0]);
     });
 });
@@ -42,7 +42,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 1, y: 2 });
         const reordered = { type: "object", properties: { y: f32, x: f32 } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, reordered);
+        const out = convertTypedBuffer({ source: src, targetSchema: reordered });
         expect(out.get(0)).toEqual({ x: 1, y: 2 });
     });
 
@@ -50,7 +50,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 1, y: 2 });
         const vec3 = { type: "object", properties: { x: f32, y: f32, z: { type: "number", precision: 1, default: 7 } } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, vec3);
+        const out = convertTypedBuffer({ source: src, targetSchema: vec3 });
         expect(out.get(0)).toEqual({ x: 1, y: 2, z: 7 });
     });
 
@@ -58,7 +58,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 50, y: 3 });
         const clamped = { type: "object", properties: { x: { type: "number", precision: 1, maximum: 10 }, y: f32 } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, clamped);
+        const out = convertTypedBuffer({ source: src, targetSchema: clamped });
         expect(out.get(0)).toEqual({ x: 10, y: 3 });
     });
 });
@@ -76,7 +76,7 @@ describe("convertTypedBuffer — array (object-holding) buffers", () => {
         src.set(0, { a: 1, b: 2 });
         src.set(1, { a: 3, b: 4 });
         const abc = { type: "object", properties: { a: num, b: num, c: { type: "number", default: 5 } } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, abc);
+        const out = convertTypedBuffer({ source: src, targetSchema: abc });
         expect(out.get(0)).toEqual({ a: 1, b: 2, c: 5 });
         expect(out.get(1)).toEqual({ a: 3, b: 4, c: 5 });
     });
@@ -85,7 +85,7 @@ describe("convertTypedBuffer — array (object-holding) buffers", () => {
         const src = createTypedBuffer(ab, 1);
         src.set(0, { a: 1, b: 2 });
         const justA = { type: "object", properties: { a: num } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, justA);
+        const out = convertTypedBuffer({ source: src, targetSchema: justA });
         expect(out.get(0)).toEqual({ a: 1 });
     });
 });
@@ -95,7 +95,7 @@ describe("convertTypedBuffer — enum & const", () => {
         const src = createTypedBuffer({ enum: ["a", "b"], default: "a" }, 2);
         src.set(0, "a");
         src.set(1, "b");
-        const out = convertTypedBuffer(src, { enum: ["a", "b", "c"], default: "a" });
+        const out = convertTypedBuffer({ source: src, targetSchema: { enum: ["a", "b", "c"], default: "a" } });
         expect([out.get(0), out.get(1)]).toEqual(["a", "b"]);
     });
 });
@@ -103,7 +103,7 @@ describe("convertTypedBuffer — enum & const", () => {
 describe("convertTypedBuffer — not convertible", () => {
     it("throws when no automatic conversion exists", () => {
         const src = createTypedBuffer(num, 1);
-        expect(() => convertTypedBuffer(src, { type: "object", properties: { x: f32 } })).toThrow(
+        expect(() => convertTypedBuffer({ source: src, targetSchema: { type: "object", properties: { x: f32 } } })).toThrow(
             /No automatic TypedBuffer conversion/,
         );
     });

--- a/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.test.ts
@@ -13,7 +13,7 @@ describe("convertTypedBuffer — numeric buffers", () => {
         const src = createTypedBuffer(num, 2);
         src.set(0, 0.1);
         src.set(1, 1.5);
-        const out = convertTypedBuffer(src, f32, 2);
+        const out = convertTypedBuffer(src, f32);
         // 1.5 is exact in f32; 0.1 rounds to the nearest f32.
         expect(out.get(1)).toBe(1.5);
         expect(out.get(0)).toBe(new Float32Array([0.1])[0]);
@@ -26,7 +26,7 @@ describe("convertTypedBuffer — numeric buffers", () => {
         src.set(1, 70000);
         src.set(2, -5);
         const capped = { type: "integer", minimum: 0, maximum: 100 } as const satisfies Schema;
-        const out = convertTypedBuffer(src, capped, 3);
+        const out = convertTypedBuffer(src, capped);
         expect([out.get(0), out.get(1), out.get(2)]).toEqual([50, 100, 0]);
     });
 });
@@ -42,7 +42,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 1, y: 2 });
         const reordered = { type: "object", properties: { y: f32, x: f32 } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, reordered, 1);
+        const out = convertTypedBuffer(src, reordered);
         expect(out.get(0)).toEqual({ x: 1, y: 2 });
     });
 
@@ -50,7 +50,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 1, y: 2 });
         const vec3 = { type: "object", properties: { x: f32, y: f32, z: { type: "number", precision: 1, default: 7 } } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, vec3, 1);
+        const out = convertTypedBuffer(src, vec3);
         expect(out.get(0)).toEqual({ x: 1, y: 2, z: 7 });
     });
 
@@ -58,7 +58,7 @@ describe("convertTypedBuffer — struct (value-type) buffers", () => {
         const src = createTypedBuffer(vec2, 1);
         src.set(0, { x: 50, y: 3 });
         const clamped = { type: "object", properties: { x: { type: "number", precision: 1, maximum: 10 }, y: f32 } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, clamped, 1);
+        const out = convertTypedBuffer(src, clamped);
         expect(out.get(0)).toEqual({ x: 10, y: 3 });
     });
 });
@@ -76,7 +76,7 @@ describe("convertTypedBuffer — array (object-holding) buffers", () => {
         src.set(0, { a: 1, b: 2 });
         src.set(1, { a: 3, b: 4 });
         const abc = { type: "object", properties: { a: num, b: num, c: { type: "number", default: 5 } } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, abc, 2);
+        const out = convertTypedBuffer(src, abc);
         expect(out.get(0)).toEqual({ a: 1, b: 2, c: 5 });
         expect(out.get(1)).toEqual({ a: 3, b: 4, c: 5 });
     });
@@ -85,7 +85,7 @@ describe("convertTypedBuffer — array (object-holding) buffers", () => {
         const src = createTypedBuffer(ab, 1);
         src.set(0, { a: 1, b: 2 });
         const justA = { type: "object", properties: { a: num } } as const satisfies Schema;
-        const out = convertTypedBuffer(src, justA, 1);
+        const out = convertTypedBuffer(src, justA);
         expect(out.get(0)).toEqual({ a: 1 });
     });
 });
@@ -95,7 +95,7 @@ describe("convertTypedBuffer — enum & const", () => {
         const src = createTypedBuffer({ enum: ["a", "b"], default: "a" }, 2);
         src.set(0, "a");
         src.set(1, "b");
-        const out = convertTypedBuffer(src, { enum: ["a", "b", "c"], default: "a" }, 2);
+        const out = convertTypedBuffer(src, { enum: ["a", "b", "c"], default: "a" });
         expect([out.get(0), out.get(1)]).toEqual(["a", "b"]);
     });
 });
@@ -103,7 +103,7 @@ describe("convertTypedBuffer — enum & const", () => {
 describe("convertTypedBuffer — not convertible", () => {
     it("throws when no automatic conversion exists", () => {
         const src = createTypedBuffer(num, 1);
-        expect(() => convertTypedBuffer(src, { type: "object", properties: { x: f32 } }, 1)).toThrow(
+        expect(() => convertTypedBuffer(src, { type: "object", properties: { x: f32 } })).toThrow(
             /No automatic TypedBuffer conversion/,
         );
     });

--- a/packages/data/src/typed-buffer/convert-typed-buffer.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.ts
@@ -13,11 +13,11 @@ import { ReadonlyTypedBuffer, TypedBuffer } from "./typed-buffer.js";
  * conversion exists it **throws** — a developer error, callers that want to
  * probe first can call `createCoerceFunction` themselves and branch on `null`.
  *
- * `capacity` sizes the new buffer (default: the source's). `count` is how many
- * leading elements to actually convert (default: everything in range) — a table
- * passes its live `rowCount` so unused rows (which may hold `undefined` in an
- * array buffer) are not run through the coercer; those slots stay at the new
- * buffer's zero/default init.
+ * `options.capacity` sizes the new buffer (default: the source's).
+ * `options.count` is how many leading elements to actually convert (default:
+ * everything in range) — a table passes its live `rowCount` so unused rows
+ * (which may hold `undefined` in an array buffer) are not run through the
+ * coercer; those slots stay at the new buffer's zero/default init.
  *
  * Source values are copied by reference into the new buffer (ECS component
  * values are never mutated in place); only newly-introduced fields get their own
@@ -27,8 +27,7 @@ import { ReadonlyTypedBuffer, TypedBuffer } from "./typed-buffer.js";
 export function convertTypedBuffer(
     source: ReadonlyTypedBuffer<unknown>,
     targetSchema: Schema,
-    capacity: number = source.capacity,
-    count: number = Math.min(capacity, source.capacity),
+    options: { readonly capacity?: number; readonly count?: number } = {},
 ): TypedBuffer<unknown> {
     const coerce = createCoerceFunction(source.schema, targetSchema);
     if (coerce === null) {
@@ -36,6 +35,8 @@ export function convertTypedBuffer(
             `No automatic TypedBuffer conversion exists from ${JSON.stringify(source.schema)} to ${JSON.stringify(targetSchema)}.`,
         );
     }
+    const capacity = options.capacity ?? source.capacity;
+    const count = options.count ?? Math.min(capacity, source.capacity);
     const target = createTypedBuffer(targetSchema, capacity);
     for (let i = 0; i < count; i++) {
         target.set(i, coerce(source.get(i)));

--- a/packages/data/src/typed-buffer/convert-typed-buffer.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.ts
@@ -1,0 +1,38 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+import { Schema } from "../schema/schema.js";
+import { createCoerceFunction } from "../schema/create-coerce-function.js";
+import { createTypedBuffer } from "./create-typed-buffer.js";
+import { ReadonlyTypedBuffer, TypedBuffer } from "./typed-buffer.js";
+
+/**
+ * Convert every element of `source` into a NEW buffer of `targetSchema`.
+ *
+ * The per-element conversion is compiled once via
+ * {@link createCoerceFunction}(source.schema, targetSchema); if no automatic
+ * conversion exists it **throws** — a developer error, callers that want to
+ * probe first can call `createCoerceFunction` themselves and branch on `null`.
+ *
+ * Source values are copied by reference into the new buffer (ECS component
+ * values are never mutated in place); only newly-introduced fields get their own
+ * cloned defaults. Width/precision loss (F64→F32, capped integers) is applied by
+ * the destination buffer as coerced values are written.
+ */
+export function convertTypedBuffer(
+    source: ReadonlyTypedBuffer<unknown>,
+    targetSchema: Schema,
+    capacity: number = source.capacity,
+): TypedBuffer<unknown> {
+    const coerce = createCoerceFunction(source.schema, targetSchema);
+    if (coerce === null) {
+        throw new Error(
+            `No automatic TypedBuffer conversion exists from ${JSON.stringify(source.schema)} to ${JSON.stringify(targetSchema)}.`,
+        );
+    }
+    const target = createTypedBuffer(targetSchema, capacity);
+    const count = Math.min(capacity, source.capacity);
+    for (let i = 0; i < count; i++) {
+        target.set(i, coerce(source.get(i)));
+    }
+    return target;
+}

--- a/packages/data/src/typed-buffer/convert-typed-buffer.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.ts
@@ -6,12 +6,18 @@ import { createTypedBuffer } from "./create-typed-buffer.js";
 import { ReadonlyTypedBuffer, TypedBuffer } from "./typed-buffer.js";
 
 /**
- * Convert every element of `source` into a NEW buffer of `targetSchema`.
+ * Convert `source` into a NEW buffer of `targetSchema`.
  *
  * The per-element conversion is compiled once via
  * {@link createCoerceFunction}(source.schema, targetSchema); if no automatic
  * conversion exists it **throws** — a developer error, callers that want to
  * probe first can call `createCoerceFunction` themselves and branch on `null`.
+ *
+ * `capacity` sizes the new buffer (default: the source's). `count` is how many
+ * leading elements to actually convert (default: everything in range) — a table
+ * passes its live `rowCount` so unused rows (which may hold `undefined` in an
+ * array buffer) are not run through the coercer; those slots stay at the new
+ * buffer's zero/default init.
  *
  * Source values are copied by reference into the new buffer (ECS component
  * values are never mutated in place); only newly-introduced fields get their own
@@ -22,6 +28,7 @@ export function convertTypedBuffer(
     source: ReadonlyTypedBuffer<unknown>,
     targetSchema: Schema,
     capacity: number = source.capacity,
+    count: number = Math.min(capacity, source.capacity),
 ): TypedBuffer<unknown> {
     const coerce = createCoerceFunction(source.schema, targetSchema);
     if (coerce === null) {
@@ -30,7 +37,6 @@ export function convertTypedBuffer(
         );
     }
     const target = createTypedBuffer(targetSchema, capacity);
-    const count = Math.min(capacity, source.capacity);
     for (let i = 0; i < count; i++) {
         target.set(i, coerce(source.get(i)));
     }

--- a/packages/data/src/typed-buffer/convert-typed-buffer.ts
+++ b/packages/data/src/typed-buffer/convert-typed-buffer.ts
@@ -13,22 +13,24 @@ import { ReadonlyTypedBuffer, TypedBuffer } from "./typed-buffer.js";
  * conversion exists it **throws** — a developer error, callers that want to
  * probe first can call `createCoerceFunction` themselves and branch on `null`.
  *
- * `options.capacity` sizes the new buffer (default: the source's).
- * `options.count` is how many leading elements to actually convert (default:
- * everything in range) — a table passes its live `rowCount` so unused rows
- * (which may hold `undefined` in an array buffer) are not run through the
- * coercer; those slots stay at the new buffer's zero/default init.
+ * `capacity` sizes the new buffer (default: the source's). `count` is how many
+ * leading elements to actually convert (default: everything in range) — a table
+ * passes its live `rowCount` so unused rows (which may hold `undefined` in an
+ * array buffer) are not run through the coercer; those slots stay at the new
+ * buffer's zero/default init.
  *
  * Source values are copied by reference into the new buffer (ECS component
  * values are never mutated in place); only newly-introduced fields get their own
  * cloned defaults. Width/precision loss (F64→F32, capped integers) is applied by
  * the destination buffer as coerced values are written.
  */
-export function convertTypedBuffer(
-    source: ReadonlyTypedBuffer<unknown>,
-    targetSchema: Schema,
-    options: { readonly capacity?: number; readonly count?: number } = {},
-): TypedBuffer<unknown> {
+export function convertTypedBuffer(options: {
+    readonly source: ReadonlyTypedBuffer<unknown>;
+    readonly targetSchema: Schema;
+    readonly capacity?: number;
+    readonly count?: number;
+}): TypedBuffer<unknown> {
+    const { source, targetSchema } = options;
     const coerce = createCoerceFunction(source.schema, targetSchema);
     if (coerce === null) {
         throw new Error(

--- a/packages/data/src/typed-buffer/index.ts
+++ b/packages/data/src/typed-buffer/index.ts
@@ -2,6 +2,7 @@
 
 export * from './typed-buffer.js';
 export * from './create-typed-buffer.js';
+export * from './convert-typed-buffer.js';
 export * from './create-struct-buffer.js';
 export * from './structs/index.js';
 export { copyToGPUBuffer } from './copy-to-gpu-buffer.js';


### PR DESCRIPTION
## Summary

Foundational building block for automated migration of persisted data: a **schema→schema value-coercion factory** and a **TypedBuffer converter** built on it. (Higher-order `Table`/`Store` in-place conversion will build on `convertTypedBuffer` in a later change.)

### `Schema.createCoerceFunction(input, output): null | (value) => value`
Analyzes the schema pair **once** and returns a specialized per-value converter to reuse across every element of a homogeneous collection — no per-element schema inspection. A **`null` return is the "not convertible" answer**; there is no separate predicate.

Supported automatic conversions:
- **number/integer → number/integer** — pass-through; clamped into range when the output declares `minimum`/`maximum` (so a capped/narrowed integer keeps its cap). Precision/width loss (F64→F32, float→int) is applied by the destination buffer's typed-array write, not here.
- **boolean → boolean**, **string → string** — identity.
- **enum → enum** — only when every input value is also an output value.
- **→ const** — any input; every element becomes the output constant.
- **object → object** — per output property: convert the matching input property, or fill a **new** property from its schema `default` (recursively). A new property with no producible default ⇒ not convertible. Input-only properties are dropped; field order is irrelevant (covers struct field reorder).
- **array → array** — element-wise via `items`; a fixed-length output longer than a fixed-length input fills the extra slots from the item default (or is not convertible without one). Covers vec3→vec4 / vec3→vec2.

Any change of kind (number↔object, number↔enum, …) returns `null`.

Exposed as `Schema.createCoerceFunction` (tree-shakeable namespace).

### `convertTypedBuffer({ source, targetSchema, capacity?, count? })`
Compiles one coerce fn via `createCoerceFunction(source.schema, targetSchema)` and maps it over the source's elements into a **new** buffer of the target schema; **throws** when not convertible (a developer error — callers that want to probe can call `createCoerceFunction` and branch on `null`). Source values are shared by reference (ECS component values are never mutated in place); newly-introduced field defaults are **cloned per element** so rows never alias one default instance.

Exposed as a standalone export from the typed-buffer barrel (not a `TypedBuffer` static: a `static` would import the `extends TypedBuffer` subclasses through `createTypedBuffer` and hit an eval-time cycle, which the `equals` static avoids only because its impl imports no subclasses).

## Tests
- `schema/create-coerce-function.test.ts` — every conversion type and every `null` case: numeric identity/clamp/integer-cap, boolean/string, enum subset (+ reject), const, object reorder/add-default/no-default-reject/drop/retype-clamp/default-clone/subfield-reject, array vec-extend/reject/truncate/variable-map, cross-kind rejects, namespace exposure.
- `typed-buffer/convert-typed-buffer.test.ts` — F64→F32 precision, integer capping, **struct** buffers (reorder / add-default / clamp), **array** (object-holding) buffers (add-default / drop), enum widening, and the not-convertible throw.

Full data suite passing; monorepo typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## In-place conversion helpers (schema migration)

Built on the above, for migrating a persisted schema forward without a full reload:

- **`coerceArchetypeColumn(archetype, component, targetSchema): boolean`** — converts one column of an archetype (a table) in place, preserving its live rows; returns `false` when the component is absent. Because an archetype bakes its column references into a specialized `insert`, the swap goes through `archetype.fromData`, which replaces the columns **and** rebuilds that baked insert so later inserts write through the converted column. Only the live `rowCount` rows are converted.
- **`coerceStoreComponent(store, component, targetSchema): void`** — converts the component's column in every archetype that carries it, then adopts `targetSchema` as the component's declared schema (so subsequently-created archetypes back it the new way). This changes a component's schema across the whole store in place.

### Object vs. struct default rule (refinement)
A new field requires a default only for a **numeric struct** (every field is packed into fixed storage, so a missing field would read as NaN). For a **plain object**, a new *non-required* field with no default is simply omitted rather than blocking the conversion; a new *required* field still needs one. Struct-ness is detected via `getStructLayout`. Covered by red/green tests.

`convertTypedBuffer` takes a single named-arguments object `{ source, targetSchema, capacity?, count? }` (`count` defaults to the full range) so a table converts only its live rows, leaving unused capacity at the new default — this avoids running an array buffer's `undefined` tail through the coercer.

### Added tests
- `ecs/store/coerce-store-component.test.ts` — struct field add across live rows + insert-after-swap through the rebuilt insert; the absent-component no-op; store-wide clamp across multiple archetypes with schema adoption and re-typed storage; and the not-convertible throw.


