### PR TITLE
feat(data-testing): add throws support to conformance cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/.claude/rules/features/data/state.md
+++ b/packages/data-ai/.claude/rules/features/data/state.md
@@ -217,7 +217,10 @@ export const cases = Conformance.cases(createTodo,
   injected service, etc. into it, never as a third positional. A transition that takes
   **no** args omits `args` from each case entirely (the shared `Case` type makes
   `args` optional exactly then). **Guard no-ops by returning an empty patch `{}`**
-  (or the unchanged slice), never throw.
+  (or the unchanged slice), never throw for an ordinary "nothing to do here"
+  condition. Reserve `throw` for a genuine precondition violation the case wants
+  to name (see "A case that expects a throw" below) — the rare exception, not the
+  default guard style.
 - **A composer merges sub-patches explicitly.** A transition built from smaller
   ones spreads them — `return { ...s, ...sub(s) }` — so each sub-patch's writes
   layer in; a transition that merely **delegates** to one sub-transition returns
@@ -294,6 +297,32 @@ export const cases = Conformance.cases(createTodo,
   `state/` — a `create()` constructor, a single-field predicate — has no `cases`
   and isn't a `(state,args)=>state` transform, so `runSpec` skips it: **keep its own
   sibling `*.test.ts`** rather than deleting it and losing coverage.
+
+### A case that expects a throw
+
+A case is normally `{ name, before, args?, after, effects? }`. When a transition
+must reject its input outright — not the "guard no-op, return `{}`" case above,
+but a genuine precondition violation the spec wants to name — declare `throws`
+instead of `after`/`effects`:
+
+```ts
+export const cases = Conformance.cases(withdrawFunds,
+    { name: "rejects a withdrawal over the balance",
+      before: { balance: 10 },
+      args: { amount: 11 },
+      throws: "insufficient funds" },   // substring the thrown Error.message must contain
+);
+```
+
+`throws: true` accepts any thrown error; a string narrows to one whose message
+**contains** it. A case can declare `after`/`effects` **or** `throws`, never
+both — the shared `Case` type makes them mutually exclusive, and there is
+nothing to compare against `after` once a call never returns a patch. The same
+case runs against the pure transform (`runSpec`) **and** the paired ecs
+transaction/action (`runFeature`/`runTransactions`/`runActions`), so a `throws`
+case proves both sides reject the same input the same way. Reach for this only
+when throwing is the transition's actual contract — most invalid input should
+still no-op per the rule above.
 
 ## Injected services and side effects
 

--- a/packages/data-ai/.claude/rules/features/services/main-service/conformance.md
+++ b/packages/data-ai/.claude/rules/features/services/main-service/conformance.md
@@ -165,7 +165,11 @@ It discovers every file exporting `cases`, enforces the two-exports rule, and
 dispatches on case shape (transition → state + effects, derivation →
 `fn(input) ≡ value`), seeding each case's `before`/`input` as a delta over
 `State.create()`. On the ECS side it resolves the reference args a case's `args`
-schema marks; the pure side reads them plain.
+schema marks; the pure side reads them plain. A transition case may declare
+`throws` instead of `after`/`effects` to assert the call rejects its input —
+see `../../data/state.md` ("A case that expects a throw"). `runSpec`,
+`runTransactions`, and `runActions` all honor it identically, so the same case
+proves the pure transform and its paired ecs op fail the same way.
 
 ## The exception — a per-surface `userId`, via the lower-level runners
 

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data-testing/src/conformance/cases.type-test.ts
+++ b/packages/data-testing/src/conformance/cases.type-test.ts
@@ -38,3 +38,17 @@ const _derivedCases: readonly unknown[] = derived.cases;
 const badArgs = { type: "object", properties: { id: { type: "string" }, count: { type: "integer" } } } as const;
 // @ts-expect-error — args type is not assignable to Schema.ToType<args>
 export const bad = cases(reparent, { args: badArgs }, { name: "bad", before: {}, args: { id: 1, count: 2 }, after: { selected: 1 } });
+
+// A `throws` case takes no `after`/`effects` — `true` for any message, or a
+// substring the thrown message must contain.
+export const throwsAny = cases(
+  reparent,
+  { name: "throws (any message)", before: {}, args: { id: 1, count: 2 }, throws: true },
+);
+export const throwsSubstring = cases(
+  reparent,
+  { name: "throws (substring)", before: {}, args: { id: 1, count: 2 }, throws: "not found" },
+);
+// A case cannot declare both `after` and `throws` — the union forbids it.
+// @ts-expect-error — `after` and `throws` are mutually exclusive
+export const badBoth = cases(reparent, { name: "bad", before: {}, args: { id: 1, count: 2 }, after: { selected: 1 }, throws: true });

--- a/packages/data-testing/src/conformance/discover.ts
+++ b/packages/data-testing/src/conformance/discover.ts
@@ -42,10 +42,13 @@ const scan = (
   return out;
 };
 
-// Transitions — files whose cases are `{ before, args?, after }` — keyed by the
-// transform's function name (the name the ecs transaction/action must share).
+// Transitions — files whose cases are `{ before, args?, after }` OR `{ before,
+// args?, throws }` — keyed by the transform's function name (the name the ecs
+// transaction/action must share). Checking either key means a module whose
+// FIRST case happens to be a `throws` case is still recognized (only the first
+// case decides the module's kind).
 export const discoverTransitions = (modules: Record<string, Record<string, unknown>>): Map<string, Discovered> =>
-  scan(modules, (c) => "after" in c);
+  scan(modules, (c) => "after" in c || "throws" in c);
 // Derivations — files whose cases are `{ input, value }` — keyed by the
 // derivation's function name (the name the ecs computed must share).
 export const discoverDerivations = (modules: Record<string, Record<string, unknown>>): Map<string, Discovered> =>

--- a/packages/data-testing/src/conformance/expect-throws.test.ts
+++ b/packages/data-testing/src/conformance/expect-throws.test.ts
@@ -1,0 +1,50 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { expectThrows } from "./expect-throws.js";
+
+describe("expectThrows", () => {
+  it("resolves when the call throws and `true` accepts any message", async () => {
+    await expect(
+      expectThrows(() => {
+        throw new Error("nope");
+      }, true),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when the thrown message contains the expected substring", async () => {
+    await expect(
+      expectThrows(() => {
+        throw new Error("invalid quantity: -1");
+      }, "invalid quantity"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when the thrown message does not contain the expected substring", async () => {
+    await expect(
+      expectThrows(() => {
+        throw new Error("something else");
+      }, "invalid quantity"),
+    ).rejects.toThrow(/expected thrown error message to include/);
+  });
+
+  it("rejects when the call does not throw at all", async () => {
+    await expect(expectThrows(() => 42, true)).rejects.toThrow(/expected a throw/);
+  });
+
+  it("supports an async call that rejects", async () => {
+    await expect(
+      expectThrows(async () => {
+        throw new Error("async failure");
+      }, "async failure"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("matches against a non-Error thrown value via String()", async () => {
+    await expect(
+      expectThrows(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw "plain string failure";
+      }, "string failure"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/data-testing/src/conformance/expect-throws.ts
+++ b/packages/data-testing/src/conformance/expect-throws.ts
@@ -1,0 +1,28 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+// Assert that invoking `run` throws (synchronously or via a rejected promise).
+// `expected: true` accepts any thrown error; a string narrows to one whose
+// `message` contains it as a substring. Shared by every runner that supports a
+// `throws` case (`runSpec`, `runTransactions`, `runActions`) so sync and async
+// transforms are asserted identically — `await` a sync throw the same as a
+// rejection, since the throw happens before the `await` inside the `try`.
+export const expectThrows = async (run: () => unknown, expected: true | string): Promise<void> => {
+  let didThrow = false;
+  let thrown: unknown;
+  try {
+    await run();
+  } catch (e) {
+    didThrow = true;
+    thrown = e;
+  }
+  if (!didThrow) {
+    const suffix = typeof expected === "string" ? ` containing "${expected}"` : "";
+    throw new Error(`expected a throw${suffix}, but none was thrown`);
+  }
+  if (typeof expected === "string") {
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    if (!message.includes(expected)) {
+      throw new Error(`expected thrown error message to include "${expected}", got: ${JSON.stringify(message)}`);
+    }
+  }
+};

--- a/packages/data-testing/src/conformance/public.ts
+++ b/packages/data-testing/src/conformance/public.ts
@@ -16,4 +16,7 @@ export { runFeature, type FeatureRunConfig, type Projection } from "./run-featur
 // For custom conformance harnesses (e.g. an ECS-system frame): compare two States
 // up to an id-bijection, the same way the runners do.
 export { assertState } from "./assert-state.js";
+// For custom conformance harnesses: assert a call throws, the same way a case's
+// `throws` field does in the built-in runners.
+export { expectThrows } from "./expect-throws.js";
 export type { SchemaSource } from "./refify.js";

--- a/packages/data-testing/src/conformance/run-actions.ts
+++ b/packages/data-testing/src/conformance/run-actions.ts
@@ -4,6 +4,7 @@ import type { Entity } from "@adobe/data/ecs";
 import type { MatchOptions } from "../match/match.js";
 import { discoverTransitions, discoverOps } from "./discover.js";
 import { expectAfter } from "./expect-after.js";
+import { expectThrows } from "./expect-throws.js";
 import type { SchemaSource } from "./refify.js";
 import { resolveArgs } from "./resolve-args.js";
 import { splitAndRecordServices, expectEffects } from "./record-effects.js";
@@ -50,7 +51,12 @@ export function runActions<Db, Store extends SchemaSource, State>(config: Action
           // Resolve entity-reference args (the fields the case's `args` schema marks)
           // to the seeded entities; a transition with no such schema passes through.
           const args = resolveArgs(input, paired.argsSchema, resolve);
-          await (action as (d: Db, a?: unknown) => Promise<void> | void)(db, args);
+          const call = action as (d: Db, a?: unknown) => Promise<void> | void;
+          if (testCase.throws !== undefined) {
+            await expectThrows(() => call(db, args), testCase.throws as true | string);
+            return;
+          }
+          await call(db, args);
           // `after` is a writes patch, compared up to an id-bijection.
           const store = config.store(db);
           expectAfter(config.toState(store), before as object, testCase.after as object, store, config.match);

--- a/packages/data-testing/src/conformance/run-spec.test.ts
+++ b/packages/data-testing/src/conformance/run-spec.test.ts
@@ -8,6 +8,15 @@ const increment = (
   { by }: { by: number },
 ): { n: number } => ({ n: state.n + by });
 
+// A `throws` case: no `after`/`effects`, just an optional message substring.
+const withdraw = (
+  state: { n: number },
+  { amount }: { amount: number },
+): { n: number } => {
+  if (amount > state.n) throw new Error(`insufficient funds: have ${state.n}, want ${amount}`);
+  return { n: state.n - amount };
+};
+
 Conformance.runSpec({
   state: { create: () => ({ n: 0 }) },
   transitions: {
@@ -28,6 +37,31 @@ Conformance.runSpec({
             before: { n: 10 },
             args: { by: 1 },
             after: { n: 11 },
+          },
+        ],
+      },
+    },
+    "./withdraw.ts": {
+      withdraw,
+      cases: {
+        cases: [
+          {
+            name: "withdraws within balance",
+            before: { n: 10 },
+            args: { amount: 4 },
+            after: { n: 6 },
+          },
+          {
+            name: "throws on any error when `throws: true`",
+            before: { n: 10 },
+            args: { amount: 11 },
+            throws: true,
+          },
+          {
+            name: "throws with a message containing the given substring",
+            before: { n: 10 },
+            args: { amount: 11 },
+            throws: "insufficient funds",
           },
         ],
       },

--- a/packages/data-testing/src/conformance/run-spec.ts
+++ b/packages/data-testing/src/conformance/run-spec.ts
@@ -4,6 +4,7 @@ import { Database, Store } from "@adobe/data/ecs";
 import { assert } from "../match/assert.js";
 import type { MatchOptions } from "../match/match.js";
 import { expectAfter } from "./expect-after.js";
+import { expectThrows } from "./expect-throws.js";
 import type { SchemaSource } from "./refify.js";
 import { recordArgServices, expectEffects } from "./record-effects.js";
 import type { DerivationCase, Effects } from "./types.js";
@@ -126,8 +127,9 @@ export const runSpec = (config: SpecRunConfig): void => {
           readonly name: string;
           readonly before: unknown;
           readonly args?: unknown;
-          readonly after: unknown;
+          readonly after?: unknown;
           readonly effects?: Effects<Record<string, unknown>>;
+          readonly throws?: true | string;
         };
         it(tc.name, async () => {
           // The pure spec reads args as authored — plain spec-ids that already match
@@ -138,6 +140,10 @@ export const runSpec = (config: SpecRunConfig): void => {
             ...(config.state?.create() ?? {}),
             ...(tc.before as Record<string, unknown>),
           };
+          if (tc.throws !== undefined) {
+            await expectThrows(() => suite.fn(before, args), tc.throws!);
+            return;
+          }
           const result = (await suite.fn(before, args)) as Record<string, unknown>;
           // The pure transform mints its own spec-ids, so compare up to an
           // id-bijection too (entity map keys always; reference fields when a

--- a/packages/data-testing/src/conformance/run-transactions.ts
+++ b/packages/data-testing/src/conformance/run-transactions.ts
@@ -4,6 +4,7 @@ import type { Entity } from "@adobe/data/ecs";
 import type { MatchOptions } from "../match/match.js";
 import { discoverTransitions, discoverOps } from "./discover.js";
 import { expectAfter } from "./expect-after.js";
+import { expectThrows } from "./expect-throws.js";
 import type { SchemaSource } from "./refify.js";
 import { resolveArgs } from "./resolve-args.js";
 import { resolver } from "./resolve.js";
@@ -43,7 +44,7 @@ export function runTransactions<Store extends SchemaSource, State>(config: Trans
     if (!paired) continue; // infrastructure / system-dispatched — no transition to conform to
     describe(`${name} transaction conforms`, () => {
       for (const testCase of paired.cases) {
-        it(testCase.name as string, () => {
+        it(testCase.name as string, async () => {
           // Case `before` is a delta over the feature default.
           const before = { ...(config.initial ?? {}), ...(testCase.before as object) } as State;
           const store = config.createStore();
@@ -52,7 +53,12 @@ export function runTransactions<Store extends SchemaSource, State>(config: Trans
           // Resolve entity-reference args (the fields the case's `args` schema marks)
           // to the seeded entities; a transition with no such schema passes through.
           const args = resolveArgs(testCase.args, paired.argsSchema, resolve);
-          (transaction as (s: Store, a?: unknown) => void)(store, args);
+          const call = transaction as (s: Store, a?: unknown) => void;
+          if (testCase.throws !== undefined) {
+            await expectThrows(() => call(store, args), testCase.throws as true | string);
+            return;
+          }
+          call(store, args);
           // `after` is a writes patch, compared up to an id-bijection (the ecs mints
           // its own ids).
           expectAfter(config.toState(store), before as object, testCase.after as object, store, config.match);

--- a/packages/data-testing/src/conformance/types.ts
+++ b/packages/data-testing/src/conformance/types.ts
@@ -42,12 +42,16 @@ type ArgsOf<F extends (...args: never[]) => unknown> = Parameters<F> extends [un
 // mention is the default and stays unchanged. (A full `before`/`after` still works
 // — it just overrides the default wholesale.) `args` is OMITTABLE exactly when the
 // transform takes none. Shared by the spec aggregator and the ecs runners.
-export type Case<State, Args> = {
-  readonly name: string;
-  readonly before: Partial<State>;
-  readonly after: Partial<State>;
-  readonly effects?: Effects<Args>;
-} & ([Args] extends [void] ? { readonly args?: undefined } : { readonly args: Args });
+//
+// A case is EITHER a normal `after`/`effects` expectation OR a `throws`
+// expectation — never both, since a thrown call never produces a writes patch or
+// records effects to assert. `throws: true` accepts any thrown error; a string
+// narrows to one the error's `message` must contain as a substring.
+export type Case<State, Args> = ({ readonly name: string; readonly before: Partial<State> } & (
+  | { readonly after: Partial<State>; readonly effects?: Effects<Args>; readonly throws?: undefined }
+  | { readonly throws: true | string; readonly after?: undefined; readonly effects?: undefined }
+)) &
+  ([Args] extends [void] ? { readonly args?: undefined } : { readonly args: Args });
 
 // A transform's cases, with the case `args` derived from the transform's own
 // signature — author `export const cases: Conformance.Cases<State, typeof theTransform>`

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- `Case` can now declare `throws: true | "substring"` instead of `after`/`effects`, asserting a transition/action rejects its input — honored uniformly by `runSpec`, `runTransactions`, and `runActions` via a shared `expectThrows` helper.
- Fixes `discoverTransitions` to recognize a `data/state/` module whose *first* case is throws-only (previously only `"after" in case` was checked, so such a module would silently fail to be discovered as a transition).
- Docs: `data-ai` rules (`state.md`, `conformance.md`) now describe the `throws` case shape and its intended, narrow use (genuine precondition rejection — not the default "guard no-op, return `{}`" style).

## Test plan
- [x] `pnpm -r run typecheck` clean across the monorepo
- [x] `pnpm -r run test` clean across the monorepo
- [x] New unit tests for `expectThrows` (`expect-throws.test.ts`)
- [x] New end-to-end fixture cases in `run-spec.test.ts` exercising `throws: true` and `throws: "substring"` through the real `runSpec` runner
- [x] New type-level tests in `cases.type-test.ts` confirming `throws` cases type-check and `after`+`throws` together is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)