### PR TITLE
feat(data): deferred durable blob writes + combined local/remote blob refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/cache/blob-ref-schema.test.ts
+++ b/packages/data/src/cache/blob-ref-schema.test.ts
@@ -1,0 +1,42 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { BlobRefSchema, isBlobRef } from "./blob-store.js";
+import { validate } from "../schema/validation/validate.js";
+
+describe("BlobRefSchema", () => {
+  it("accepts a local-only ref", () => {
+    expect(validate(BlobRefSchema, { localBlobRef: "abc" })).toEqual([]);
+  });
+
+  it("accepts a remote-only ref", () => {
+    expect(validate(BlobRefSchema, { remoteBlobRef: "http://x/a" })).toEqual([]);
+  });
+
+  it("accepts a combined ref (both keys present)", () => {
+    expect(
+      validate(BlobRefSchema, { localBlobRef: "abc", remoteBlobRef: "http://x/a" })
+    ).toEqual([]);
+  });
+
+  it("rejects an empty ref (at least one key required)", () => {
+    expect(validate(BlobRefSchema, {}).length).toBeGreaterThan(0);
+  });
+
+  it("rejects extra properties", () => {
+    expect(
+      validate(BlobRefSchema, { localBlobRef: "abc", extra: 1 }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("rejects a non-http remote url", () => {
+    expect(
+      validate(BlobRefSchema, { remoteBlobRef: "ftp://x/a" }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("guards a combined ref as a BlobRef", () => {
+    expect(isBlobRef({ localBlobRef: "abc", remoteBlobRef: "http://x/a" })).toBe(
+      true
+    );
+  });
+});

--- a/packages/data/src/cache/blob-store.browser.test.ts
+++ b/packages/data/src/cache/blob-store.browser.test.ts
@@ -294,8 +294,14 @@ describe("blobStore", () => {
             expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
             expect(testBlobStore._testGetBorrowCount(combined)).toBe(2);
 
+            // The shared object URL must be revoked exactly once, only after the
+            // last of the two borrows (across both ref shapes) is returned.
             testBlobStore.returnUrl(url1);
+            expect(mockRevokeObjectURL).not.toHaveBeenCalled();
             testBlobStore.returnUrl(url2);
+            expect(mockRevokeObjectURL).toHaveBeenCalledTimes(1);
+            expect(mockRevokeObjectURL).toHaveBeenCalledWith(url1);
+            expect(testBlobStore._testGetBorrowCount(combined)).toBe(0);
         });
     });
 });

--- a/packages/data/src/cache/blob-store.browser.test.ts
+++ b/packages/data/src/cache/blob-store.browser.test.ts
@@ -2,6 +2,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { type BlobStore, createBlobStore } from "./blob-store.js";
 
+// Unique content per test so hashes never collide across the shared
+// "blobstore" Cache-API namespace.
+function uniqueBlob(): Blob {
+  return new Blob([`content-${Math.random()}-${Date.now()}`], {
+    type: "text/plain",
+  });
+}
+const REMOTE_URL = "http://example.com/asset";
+
 describe("blobStore", () => {
     // Mock URL.createObjectURL and URL.revokeObjectURL
     const mockCreateObjectURL = vi.fn((blob: Blob) => `blob:${Math.random()}`);
@@ -153,4 +162,140 @@ describe("blobStore", () => {
             expect(mockRevokeObjectURL).toHaveBeenCalledWith(url1);
         });
     });
-}); 
+
+    describe("deferred durability", () => {
+        it("serves a blob immediately after getRef, and flush resolves", async () => {
+            const blob = uniqueBlob();
+            const ref = await testBlobStore.getRef(blob);
+
+            const got = await testBlobStore.getBlob(ref);
+            expect(await got?.text()).toBe(await blob.text());
+
+            await expect(testBlobStore.flush()).resolves.toBeUndefined();
+        });
+    });
+
+    describe("combined blob refs (local + remote)", () => {
+        const makeFetchSpy = () => vi.spyOn(globalThis, "fetch");
+        let fetchSpy: ReturnType<typeof makeFetchSpy>;
+
+        beforeEach(() => {
+            fetchSpy = makeFetchSpy();
+        });
+        afterEach(() => {
+            fetchSpy.mockRestore();
+        });
+
+        it("resolves locally without fetching when the bytes are present", async () => {
+            const blob = uniqueBlob();
+            const localRef = await testBlobStore.getRef(blob);
+            const combined = testBlobStore.withRemoteUrl(localRef, REMOTE_URL);
+
+            fetchSpy.mockClear();
+            const got = await testBlobStore.getBlob(combined);
+
+            expect(await got?.text()).toBe(await blob.text());
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it("falls back to remote on local miss, repopulates, then serves locally", async () => {
+            const blob = uniqueBlob();
+            const localRef = await testBlobStore.getRef(blob);
+            // Drop the local bytes so the ref must re-derive from remote.
+            await testBlobStore.releaseBlob(localRef);
+            const combined = testBlobStore.withRemoteUrl(localRef, REMOTE_URL);
+
+            fetchSpy.mockImplementation(async () => new Response(blob));
+
+            const first = await testBlobStore.getBlob(combined);
+            expect(await first?.text()).toBe(await blob.text());
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            // The remote fetch repopulated the local cache; the next read is local.
+            const second = await testBlobStore.getBlob(combined);
+            expect(await second?.text()).toBe(await blob.text());
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("withRemoteUrl rejects a non-http url", async () => {
+            const localRef = await testBlobStore.getRef(uniqueBlob());
+            expect(() => testBlobStore.withRemoteUrl(localRef, "ftp://x/a")).toThrow();
+        });
+
+        it("withRemoteUrl rejects a ref without a local hash", () => {
+            const remoteRef = testBlobStore.createRemoteBlobRef(REMOTE_URL);
+            expect(() => testBlobStore.withRemoteUrl(remoteRef, "http://y/a")).toThrow();
+        });
+
+        it("fetches a remote-only ref via the network", async () => {
+            const blob = uniqueBlob();
+            const remoteRef = testBlobStore.createRemoteBlobRef(REMOTE_URL);
+            fetchSpy.mockImplementation(async () => new Response(blob));
+
+            const got = await testBlobStore.getBlob(remoteRef);
+
+            expect(await got?.text()).toBe(await blob.text());
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("serves matching remote bytes and repopulates when verifyRemoteHash is enabled", async () => {
+            const verifying = createBlobStore({ verifyRemoteHash: true });
+            const blob = uniqueBlob();
+            const localRef = await verifying.getRef(blob);
+            await verifying.releaseBlob(localRef);
+            const combined = verifying.withRemoteUrl(localRef, REMOTE_URL);
+
+            // Remote serves the exact bytes the hash was computed from.
+            fetchSpy.mockImplementation(async () => new Response(blob));
+
+            const first = await verifying.getBlob(combined);
+            expect(await first?.text()).toBe(await blob.text());
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+            // Repopulated locally: the next read does not hit the network again.
+            const second = await verifying.getBlob(combined);
+            expect(await second?.text()).toBe(await blob.text());
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("throws on a remote hash mismatch when verifyRemoteHash is enabled", async () => {
+            const verifying = createBlobStore({ verifyRemoteHash: true });
+            const expected = uniqueBlob();
+            const localRef = await verifying.getRef(expected);
+            await verifying.releaseBlob(localRef);
+            const combined = verifying.withRemoteUrl(localRef, REMOTE_URL);
+
+            // Remote serves different bytes than the ref's content hash.
+            const wrong = uniqueBlob();
+            fetchSpy.mockImplementation(async () => new Response(wrong));
+
+            await expect(verifying.getBlob(combined)).rejects.toThrow(/mismatch/);
+        });
+
+        it("hasBlob is true for a combined ref on local miss (remote present)", async () => {
+            const blob = uniqueBlob();
+            const localRef = await testBlobStore.getRef(blob);
+            await testBlobStore.releaseBlob(localRef);
+            const combined = testBlobStore.withRemoteUrl(localRef, REMOTE_URL);
+
+            expect(await testBlobStore.hasBlob(localRef)).toBe(false);
+            expect(await testBlobStore.hasBlob(combined)).toBe(true);
+        });
+
+        it("canonicalizes identity on the hash: combined == local-only", async () => {
+            const blob = uniqueBlob();
+            const localRef = await testBlobStore.getRef(blob);
+            const combined = testBlobStore.withRemoteUrl(localRef, REMOTE_URL);
+
+            const url1 = await testBlobStore.borrowUrl(localRef);
+            const url2 = await testBlobStore.borrowUrl(combined);
+
+            expect(url1).toBe(url2);
+            expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
+            expect(testBlobStore._testGetBorrowCount(combined)).toBe(2);
+
+            testBlobStore.returnUrl(url1);
+            testBlobStore.returnUrl(url2);
+        });
+    });
+});

--- a/packages/data/src/cache/blob-store.ts
+++ b/packages/data/src/cache/blob-store.ts
@@ -1,6 +1,6 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
-import { type AsyncCache } from "./async-cache.js";
-import { getManagedPersistentCache } from "./get-persistent-cache.js";
+import { getDeferredManagedPersistentCache } from "./get-persistent-cache.js";
+import { type DeferredFallbackAsyncCache } from "./deferred-fallback-async-cache.js";
 import { type Schema } from "../schema/index.js";
 import { blobToHash } from "./functions/hashing/blob-to-hash.js";
 import { preventParallelExecution } from "./functions/prevent-parallel-execution.js";
@@ -30,8 +30,26 @@ const LocalBlobRefSchema = {
 } as const satisfies Schema;
 type LocalBlobRef = Schema.ToType<typeof LocalBlobRefSchema>;
 
+/**
+ * A ref holding both keys: the content hash (identity) plus a persistent,
+ * immutable URL the same content is re-fetchable from. Lets a local asset be
+ * augmented with a remote URL on save without changing identity, keeping the
+ * local fast-path while guaranteeing re-derivability from a cold cache.
+ */
+const CombinedBlobRefSchema = {
+  required: ["localBlobRef", "remoteBlobRef"],
+  properties: {
+    localBlobRef: { type: "string" },
+    remoteBlobRef: RemoteUrlSchema,
+  },
+  additionalProperties: false,
+} as const satisfies Schema;
+type CombinedBlobRef = Schema.ToType<typeof CombinedBlobRefSchema>;
+
+// Each `oneOf` member forbids the other's extra key, so a value matches exactly
+// one shape: remote-only, local-only, or combined (both keys present).
 export const BlobRefSchema = {
-  oneOf: [RemoteBlobRefSchema, LocalBlobRefSchema],
+  oneOf: [RemoteBlobRefSchema, LocalBlobRefSchema, CombinedBlobRefSchema],
 } as const satisfies Schema;
 
 /**
@@ -41,12 +59,18 @@ export const BlobRefSchema = {
  */
 export type BlobRef = Schema.ToType<typeof BlobRefSchema>;
 
-function isRemoteBlobRef(ref: unknown): ref is RemoteBlobRef {
+// A ref carrying a content hash (local-only or combined) / a remote URL
+// (remote-only or combined). The guards narrow to these so a combined ref keeps
+// both capabilities available to the caller.
+type WithLocalRef = LocalBlobRef | CombinedBlobRef;
+type WithRemoteRef = RemoteBlobRef | CombinedBlobRef;
+
+function isRemoteBlobRef(ref: unknown): ref is WithRemoteRef {
   const maybe = ref as Partial<RemoteBlobRef> | undefined;
   return typeof maybe?.remoteBlobRef === "string";
 }
 
-function isLocalBlobRef(ref: unknown): ref is LocalBlobRef {
+function isLocalBlobRef(ref: unknown): ref is WithLocalRef {
   const maybe = ref as Partial<LocalBlobRef> | undefined;
   return typeof maybe?.localBlobRef === "string";
 }
@@ -74,8 +98,17 @@ function isRemoteUrl(url: string): url is RemoteUrl {
   return url.startsWith(remoteUrlPrefix);
 }
 
-function toRequest(ref: LocalBlobRef) {
+function toRequest(ref: WithLocalRef) {
   return new Request(`${window.location.origin}/${ref.localBlobRef}`);
+}
+
+// Canonical identity key. Content identity (the hash) wins when present, so a
+// combined ref and a local-only ref with the same hash canonicalize equal and
+// share borrow/dedup state; a promotion (adding a URL) does not change identity.
+function toRefKey(ref: BlobRef): string {
+  return isLocalBlobRef(ref)
+    ? `local:${ref.localBlobRef}`
+    : `remote:${ref.remoteBlobRef}`;
 }
 
 /**
@@ -91,8 +124,21 @@ export interface BlobStore {
    * Stores a blob and returns a reference to it.
    * Blob references are based upon the content and type of the Blob.
    * If an equivalent blob is stored, an equivalent reference will be returned every time.
+   *
+   * The returned ref is readable immediately, but its durable (storage-tier)
+   * write is deferred off the critical path. Any layer that persists a document
+   * containing a local blob ref MUST await {@link BlobStore.flush} first, or the
+   * persisted ref may point at bytes that never reached storage and will not
+   * resolve after reload.
    */
   getRef(b: Blob | string): Promise<BlobRef>;
+  /**
+   * Resolves once every deferred blob write has reached durable storage.
+   * Rejects if any deferred write failed. Call this before persisting any
+   * document that references local blob refs — it is the durability barrier
+   * that makes deferred writes safe.
+   */
+  flush(): Promise<void>;
   /**
    * Gets a blob from the blob store or null if it is not available.
    */
@@ -121,6 +167,15 @@ export interface BlobStore {
    */
   createRemoteBlobRef(url: string): BlobRef;
   /**
+   * Augments an existing local blob ref with a remote URL, producing a combined
+   * ref (same content identity, now also re-fetchable at the URL). The URL must
+   * start with http and MUST serve immutable content whose hash equals the
+   * ref's `localBlobRef`; the local fast-path and dedup identity are preserved.
+   * @param ref A local (or already-combined) blob ref.
+   * @param url The persistent, immutable URL the same content is served from.
+   */
+  withRemoteUrl(ref: BlobRef, url: string): BlobRef;
+  /**
    * TEST ONLY: Gets the current borrow count for a blob reference.
    * This should only be used in tests to verify reference counting behavior.
    * @param r The blob reference to check
@@ -130,17 +185,31 @@ export interface BlobStore {
 }
 
 /**
+ * Options for {@link createBlobStore}.
+ */
+export interface BlobStoreOptions {
+  /**
+   * When true, bytes fetched via the remote fallback of a combined ref are
+   * re-hashed and compared to the ref's `localBlobRef`; a mismatch throws
+   * rather than serving unexpected bytes. Defaults to false (remote content is
+   * contractually immutable). Enable in debug/verification builds.
+   */
+  verifyRemoteHash?: boolean;
+}
+
+/**
  * Creates a new blob store instance.
  */
-export function createBlobStore() {
+export function createBlobStore(options: BlobStoreOptions = {}) {
+  const { verifyRemoteHash = false } = options;
   // Lazy-init the persistent cache so that importing this module on a
   // runtime without `globalThis.caches` (e.g. Node) does not produce an
   // unhandled rejection. The cache promise is only kicked off the first
   // time a blob store method actually needs it. See CLAUDE.md for the
   // rationale behind the lazy-init pattern.
-  let cachePromiseInternal: Promise<AsyncCache<Request, Response>> | undefined;
-  const cachePromise = (): Promise<AsyncCache<Request, Response>> =>
-    (cachePromiseInternal ??= getManagedPersistentCache("blobstore", {
+  let cachePromiseInternal: Promise<DeferredFallbackAsyncCache> | undefined;
+  const cachePromise = (): Promise<DeferredFallbackAsyncCache> =>
+    (cachePromiseInternal ??= getDeferredManagedPersistentCache("blobstore", {
       maximumMemoryEntries: 10,
       maximumStorageEntries: 1000,
     }));
@@ -167,36 +236,68 @@ export function createBlobStore() {
     return ref;
   }
 
+  // Reads from the local cache only (memory -> pending -> storage), no network.
+  async function getLocalResponse(
+    r: WithLocalRef
+  ): Promise<Response | undefined> {
+    return (await cachePromise()).match(toRequest(r));
+  }
+
   async function hasBlob(r: BlobRef): Promise<boolean> {
-    if (isRemoteBlobRef(r)) {
+    // Local hit is authoritative and cheap. A remote URL is assumed available
+    // (remote content is contractually immutable), so mirror that here.
+    if (isLocalBlobRef(r) && (await getLocalResponse(r)) !== undefined) {
       return true;
     }
-    const cache = await cachePromise();
-    const response = await cache.match(toRequest(r));
-    return response !== undefined;
+    return isRemoteBlobRef(r);
   }
 
   async function getBlob(r?: BlobRef | null): Promise<Blob | null> {
     if (!r) {
       return null;
     }
-    const response = await (isRemoteBlobRef(r)
-      ? fetch(r.remoteBlobRef)
-      : (await cachePromise()).match(toRequest(r)));
-    if (!response) {
-      return null;
+    // Local-first: a combined ref resolves from cache with no network when the
+    // bytes are present.
+    if (isLocalBlobRef(r)) {
+      const local = await getLocalResponse(r);
+      if (local) {
+        return local.blob();
+      }
     }
-    if (!response.ok) {
-      // this should only happen with remote urls. local blob responses are always ok.
-      throw new Error(response.statusText);
+    // Remote fallback: remote-only refs, or a combined ref whose local bytes
+    // have been evicted. Self-heal by repopulating the local cache under the
+    // known hash so the next read is served locally.
+    if (isRemoteBlobRef(r)) {
+      const response = await fetch(r.remoteBlobRef);
+      if (!response) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const blob = await response.blob();
+      if (isLocalBlobRef(r)) {
+        if (verifyRemoteHash) {
+          const actual = await blobToHash(blob);
+          if (actual !== r.localBlobRef) {
+            // Remote violated its immutability contract, or the URL is wrong.
+            throw new Error(
+              `Remote blob hash mismatch: expected ${r.localBlobRef}, got ${actual} from ${r.remoteBlobRef}`
+            );
+          }
+        }
+        const cache = await cachePromise();
+        await cache.put(toRequest(r), new Response(blob));
+      }
+      return blob;
     }
-    return response.blob();
+    return null;
   }
 
   async function releaseBlob(r: BlobRef): Promise<void> {
     if (isLocalBlobRef(r)) {
       const cache = await cachePromise();
-      cache.delete(toRequest(r));
+      await cache.delete(toRequest(r));
     }
   }
 
@@ -204,22 +305,29 @@ export function createBlobStore() {
    * prevent parallel execution to avoid race condition in borrowUrl while awaiting getBlob
    */
   const borrowUrlInternalNoIncrement = preventParallelExecution(async (key: string, r: BlobRef): Promise<{ url: string; count: number } | null> => {
+    // Local-first: hand out an object URL when the bytes are present locally.
+    if (isLocalBlobRef(r)) {
+      const response = await getLocalResponse(r);
+      if (response) {
+        const url = URL.createObjectURL(await response.blob());
+        const existing = { url, count: 0 };
+        borrowedUrls.set(key, existing);
+        urlToKey.set(url, key);
+        return existing;
+      }
+    }
+    // Otherwise defer to the remote URL directly (the browser fetches/caches it).
     if (isRemoteBlobRef(r)) {
       return { url: r.remoteBlobRef, count: 0 };
     }
-    const blob = await getBlob(r);
-    if (!blob) {
-      return null;
-    }
-    const url = URL.createObjectURL(blob);
-    const existing = { url, count: 0 };
-    borrowedUrls.set(key, existing);
-    urlToKey.set(url, key);
-    return existing;
+    return null;
   });
 
-  async function borrowUrl(r: BlobRef): Promise<string | null> {
-    const key = JSON.stringify(r);
+  async function borrowUrl(r: BlobRef | null): Promise<string | null> {
+    if (!r) {
+      return null;
+    }
+    const key = toRefKey(r);
     const existing = borrowedUrls.get(key) ?? await borrowUrlInternalNoIncrement(key, r);
     if (!existing) {
       return null;
@@ -258,19 +366,41 @@ export function createBlobStore() {
     return { remoteBlobRef: url } satisfies RemoteBlobRef;
   }
 
+  function withRemoteUrl(ref: BlobRef, url: string): BlobRef {
+    if (!isLocalBlobRef(ref)) {
+      throw new Error(
+        `withRemoteUrl requires a local blob ref (with a content hash)`
+      );
+    }
+    if (!isRemoteUrl(url)) {
+      throw new Error(
+        `Invalid url, expected to start with (${remoteUrlPrefix}): ${url}`
+      );
+    }
+    return {
+      localBlobRef: ref.localBlobRef,
+      remoteBlobRef: url,
+    } satisfies CombinedBlobRef;
+  }
+
+  async function flush(): Promise<void> {
+    await (await cachePromise()).flush();
+  }
+
   function _testGetBorrowCount(r: BlobRef): number {
-    const key = JSON.stringify(r);
-    return borrowedUrls.get(key)?.count ?? 0;
+    return borrowedUrls.get(toRefKey(r))?.count ?? 0;
   }
 
   return {
     getRef,
+    flush,
     getBlob,
     hasBlob,
     borrowUrl,
     returnUrl,
     releaseBlob,
     createRemoteBlobRef,
+    withRemoteUrl,
     _testGetBorrowCount,
   } as const satisfies BlobStore;
 }

--- a/packages/data/src/cache/deferred-fallback-async-cache.test.ts
+++ b/packages/data/src/cache/deferred-fallback-async-cache.test.ts
@@ -1,0 +1,186 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect, vi } from "vitest";
+import { type AsyncCache } from "./async-cache.js";
+import { createDeferredFallbackAsyncCache } from "./deferred-fallback-async-cache.js";
+
+// A tiny in-memory tier keyed by request url. Cloning mirrors the real tiers so
+// a Response body can be read by more than one consumer.
+function createFakeTier() {
+  const store = new Map<string, Response>();
+  const cache: AsyncCache<Request, Response> = {
+    async put(key, value) {
+      store.set(key.url, value.clone());
+    },
+    async match(key) {
+      return store.get(key.url)?.clone();
+    },
+    async delete(key) {
+      store.delete(key.url);
+    },
+  };
+  return { store, cache };
+}
+
+// A slow tier whose writes can be blocked, released, failed, and counted.
+function createControllableSlowTier() {
+  const store = new Map<string, Response>();
+  let gate: Promise<void> | undefined;
+  let openGate: (() => void) | undefined;
+  let failNext = false;
+  const putSpy = vi.fn();
+
+  const cache: AsyncCache<Request, Response> = {
+    async put(key, value) {
+      putSpy(key.url);
+      if (gate) {
+        await gate;
+      }
+      if (failNext) {
+        failNext = false;
+        throw new Error("quota exceeded");
+      }
+      store.set(key.url, value.clone());
+    },
+    async match(key) {
+      return store.get(key.url)?.clone();
+    },
+    async delete(key) {
+      store.delete(key.url);
+    },
+  };
+
+  return {
+    store,
+    cache,
+    putSpy,
+    blockWrites() {
+      gate = new Promise<void>((resolve) => {
+        openGate = resolve;
+      });
+    },
+    releaseWrites() {
+      openGate?.();
+      gate = undefined;
+      openGate = undefined;
+    },
+    failNextWrite() {
+      failNext = true;
+    },
+  };
+}
+
+const req = (url: string) => new Request(`https://test/${url}`);
+const res = (body: string) => new Response(body);
+const bodyOf = async (r: Response | undefined) => (r ? await r.text() : undefined);
+
+describe("createDeferredFallbackAsyncCache", () => {
+  it("resolves put before the durable write completes", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.blockWrites();
+    await cache.put(req("a"), res("A"));
+
+    // The durable write has not landed yet...
+    expect(slow.store.has("https://test/a")).toBe(false);
+    // ...but the value is already readable.
+    expect(await bodyOf(await cache.match(req("a")))).toBe("A");
+
+    slow.releaseWrites();
+    await cache.flush();
+    expect(slow.store.has("https://test/a")).toBe(true);
+  });
+
+  it("serves reads from pendingWrites after the fast tier evicts", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.blockWrites();
+    await cache.put(req("a"), res("A"));
+
+    // Simulate the bounded fast tier evicting the entry before its durable
+    // write lands. The value must still resolve via pendingWrites.
+    await fast.cache.delete(req("a"));
+    expect(await bodyOf(await cache.match(req("a")))).toBe("A");
+
+    // After flush drains pendingWrites, the value is served from the slow tier.
+    slow.releaseWrites();
+    await cache.flush();
+    expect(await bodyOf(await cache.match(req("a")))).toBe("A");
+  });
+
+  it("flush resolves once every deferred write has landed", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.blockWrites();
+    await cache.put(req("a"), res("A"));
+    await cache.put(req("b"), res("B"));
+    expect(slow.store.size).toBe(0);
+
+    slow.releaseWrites();
+    await cache.flush();
+    expect(slow.store.size).toBe(2);
+  });
+
+  it("surfaces a durable-write failure through flush(), not silently", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.failNextWrite();
+    await cache.put(req("a"), res("A"));
+
+    await expect(cache.flush()).rejects.toBeInstanceOf(AggregateError);
+    // The bytes remain readable in-session even though the durable write failed.
+    expect(await bodyOf(await cache.match(req("a")))).toBe("A");
+  });
+
+  it("delete removes a pending value from every tier", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    await cache.put(req("a"), res("A"));
+    await cache.flush();
+    await cache.delete(req("a"));
+
+    expect(await cache.match(req("a"))).toBeUndefined();
+    expect(slow.store.has("https://test/a")).toBe(false);
+  });
+
+  it("delete is not resurrected by an in-flight deferred write", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.blockWrites();
+    await cache.put(req("a"), res("A"));
+
+    // Delete races the still-gated durable write.
+    const deleted = cache.delete(req("a"));
+    slow.releaseWrites();
+    await deleted;
+
+    expect(await cache.match(req("a"))).toBeUndefined();
+    expect(slow.store.has("https://test/a")).toBe(false);
+  });
+
+  it("coalesces repeated writes of the same key into one durable write", async () => {
+    const fast = createFakeTier();
+    const slow = createControllableSlowTier();
+    const cache = createDeferredFallbackAsyncCache(fast.cache, slow.cache);
+
+    slow.blockWrites();
+    await cache.put(req("a"), res("A"));
+    await cache.put(req("a"), res("A"));
+    await cache.put(req("a"), res("A"));
+
+    slow.releaseWrites();
+    await cache.flush();
+    expect(slow.putSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/data/src/cache/deferred-fallback-async-cache.ts
+++ b/packages/data/src/cache/deferred-fallback-async-cache.ts
@@ -1,0 +1,111 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { type AsyncCache } from "./async-cache.js";
+
+/**
+ * A fallback cache whose durable (slower/larger) write is deferred off the
+ * critical path. Like {@link createFallbackAsyncCache} it reads faster-first
+ * and writes both tiers, but `put` resolves as soon as the fast tier has the
+ * value — the slow-tier write runs in the background.
+ *
+ * Between `put` returning and the background write landing, the value lives in
+ * an in-memory `pendingWrites` map so it is always readable (the fast tier is
+ * bounded and may evict the entry before its durable write completes). `flush`
+ * is the durability barrier: it resolves once every pending durable write has
+ * completed, and rejects if any failed.
+ */
+export interface DeferredFallbackAsyncCache extends AsyncCache<Request, Response> {
+  /**
+   * Resolves once all deferred durable (slow-tier) writes have completed.
+   * Rejects with an `AggregateError` if any deferred write has failed and has
+   * not since been superseded by a successful write of the same key.
+   *
+   * Any layer that persists a reference to a value written here MUST await
+   * `flush()` first — otherwise the persisted reference may point at bytes that
+   * never reached durable storage and will not resolve after reload.
+   */
+  flush(): Promise<void>;
+}
+
+/**
+ * Creates a fallback cache that defers the durable write.
+ * @param fasterSmaller the fast, bounded tier (awaited by `put`).
+ * @param slowerLarger the durable tier (written in the background).
+ */
+export function createDeferredFallbackAsyncCache(
+  fasterSmaller: AsyncCache<Request, Response>,
+  slowerLarger: AsyncCache<Request, Response>
+): DeferredFallbackAsyncCache {
+  // Bytes whose durable write has not yet landed, keyed by request url. Holds a
+  // strong clone so the value survives fast-tier eviction until it is durable.
+  const pendingWrites = new Map<string, Response>();
+  // In-flight durable writes, keyed by url, so repeated puts of the same
+  // content (same hash => same url) collapse to a single write.
+  const inFlight = new Map<string, Promise<void>>();
+  // Durable-write failures, keyed by url. Cleared when a later write of the
+  // same url succeeds. Surfaced through flush().
+  const failures = new Map<string, unknown>();
+
+  return {
+    async put(key: Request, value: Response): Promise<void> {
+      const { url } = key;
+      // Fast tier is on the critical path; await it so read-after-write holds
+      // even if the entry is never consulted through pendingWrites.
+      await fasterSmaller.put(key, value.clone());
+      // Register the bytes so reads resolve before the durable write lands.
+      pendingWrites.set(url, value.clone());
+      // Schedule (or reuse) the durable write off the critical path.
+      if (!inFlight.has(url)) {
+        const write = slowerLarger
+          .put(key, value.clone())
+          .then(() => {
+            pendingWrites.delete(url);
+            failures.delete(url);
+          })
+          .catch((error: unknown) => {
+            // Keep the pending bytes so in-session reads still resolve, and
+            // record the failure so flush() can surface it.
+            failures.set(url, error);
+          })
+          .finally(() => {
+            inFlight.delete(url);
+          });
+        inFlight.set(url, write);
+      }
+    },
+
+    async match(key: Request): Promise<Response | undefined> {
+      return (
+        (await fasterSmaller.match(key)) ??
+        pendingWrites.get(key.url)?.clone() ??
+        (await slowerLarger.match(key))
+      );
+    },
+
+    async delete(key: Request): Promise<void> {
+      const { url } = key;
+      pendingWrites.delete(url);
+      failures.delete(url);
+      // If a deferred write is still in flight, let it settle first — otherwise
+      // it could land after our delete and resurrect the entry in the durable
+      // tier.
+      const inflightWrite = inFlight.get(url);
+      if (inflightWrite) {
+        await inflightWrite.catch(() => {});
+      }
+      await Promise.all([fasterSmaller.delete(key), slowerLarger.delete(key)]);
+    },
+
+    async flush(): Promise<void> {
+      // Drain in-flight writes, including any scheduled while we awaited.
+      while (inFlight.size > 0) {
+        await Promise.allSettled([...inFlight.values()]);
+      }
+      if (failures.size > 0) {
+        throw new AggregateError(
+          [...failures.values()],
+          "deferred durable write(s) failed"
+        );
+      }
+    },
+  };
+}

--- a/packages/data/src/cache/get-persistent-cache.ts
+++ b/packages/data/src/cache/get-persistent-cache.ts
@@ -1,8 +1,17 @@
 // © 2026 Adobe. MIT License. See /LICENSE for details.
 import type { AsyncCache, AsyncCacheWithKeys } from "./async-cache.js";
 import { createFallbackAsyncCache } from "./fallback-async-cache.js";
+import {
+  createDeferredFallbackAsyncCache,
+  type DeferredFallbackAsyncCache,
+} from "./deferred-fallback-async-cache.js";
 import { createManagedAsyncCache } from "./managed-async-cache.js";
 import { createMemoryAsyncCache } from "./memory-async-cache.js";
+
+interface ManagedCacheOptions {
+  maximumMemoryEntries: number;
+  maximumStorageEntries: number;
+}
 
 /**
  * Gets a persistent async cache.
@@ -17,19 +26,15 @@ async function getUnmanagedPersistentCache(
 }
 
 /**
- * Gets a managed persistent cache using both fast memory layer and slower storage layer.
- * @param name The namespace for this persistent cache, used to isolate cache storage.
- * @param maximumMemoryEntries
- * @param maximumStorageEntries
- * @returns
+ * Builds the bounded memory and storage tiers shared by the managed caches.
  */
-export async function getManagedPersistentCache(
+async function createManagedTiers(
   name: string,
-  options: {
-    maximumMemoryEntries: number;
-    maximumStorageEntries: number;
-  }
-): Promise<AsyncCache<Request, Response>> {
+  options: ManagedCacheOptions
+): Promise<{
+  memoryCache: AsyncCache<Request, Response>;
+  storageCache: AsyncCache<Request, Response>;
+}> {
   const memoryCache = createManagedAsyncCache(
     createMemoryAsyncCache(),
     options.maximumMemoryEntries
@@ -38,5 +43,34 @@ export async function getManagedPersistentCache(
     await getUnmanagedPersistentCache(name),
     options.maximumStorageEntries
   );
+  return { memoryCache, storageCache };
+}
+
+/**
+ * Gets a managed persistent cache using both fast memory layer and slower storage layer.
+ * @param name The namespace for this persistent cache, used to isolate cache storage.
+ * @param options bounds for the memory and storage tiers.
+ */
+export async function getManagedPersistentCache(
+  name: string,
+  options: ManagedCacheOptions
+): Promise<AsyncCache<Request, Response>> {
+  const { memoryCache, storageCache } = await createManagedTiers(name, options);
   return createFallbackAsyncCache(memoryCache, storageCache);
+}
+
+/**
+ * Like {@link getManagedPersistentCache}, but the durable (storage-tier) write
+ * is deferred off the critical path — `put` resolves once the memory tier has
+ * the value, and the returned cache exposes `flush()` as the durability
+ * barrier. See {@link DeferredFallbackAsyncCache}.
+ * @param name The namespace for this persistent cache, used to isolate cache storage.
+ * @param options bounds for the memory and storage tiers.
+ */
+export async function getDeferredManagedPersistentCache(
+  name: string,
+  options: ManagedCacheOptions
+): Promise<DeferredFallbackAsyncCache> {
+  const { memoryCache, storageCache } = await createManagedTiers(name, options);
+  return createDeferredFallbackAsyncCache(memoryCache, storageCache);
 }

--- a/packages/data/src/functions/serialization/serialize-to-storage.ts
+++ b/packages/data/src/functions/serialization/serialize-to-storage.ts
@@ -8,6 +8,9 @@ export const serializeToStorage = async <T>(data: T, id: string, storage: Storag
         blobStore.getRef(json),
         blobStore.getRef(binary)
     ]);
+    // Blob writes are deferred; flush before persisting the refs so they cannot
+    // point at bytes that never reached durable storage. See BlobStore.flush.
+    await blobStore.flush();
     storage.setItem(id, JSON.stringify({ json: jsonBlobRef, binary: binaryBlobRef }));
 }
 


### PR DESCRIPTION
## Description

Two related changes to `@adobe/data`'s `blobStore`, sharing one durability model.

### Part 1 — Deferred durable writes + `flush()`
- New `createDeferredFallbackAsyncCache(memory, storage)`: `put` awaits the fast tier and schedules the durable write in the background; `match` reads memory → `pendingWrites` → storage; `flush()` drains pending writes and **rejects with an `AggregateError`** on failure (no silent swallowing); repeated writes of the same key **coalesce**; `delete` waits out any in-flight write so it can't be resurrected.
- The static `blobStore` uses this wrapper, so every consumer gets deferred durability by default. `getRef` returns after the memory write; `BlobStore.flush()` is the documented durability barrier.
- `serialize-to-storage` now awaits `blobStore.flush()` before persisting refs.

### Part 2 — Combined BlobRef (local + remote)
- `BlobRefSchema` relaxed to a 3-member `oneOf` (remote-only / local-only / combined), each `additionalProperties: false`.
- `getBlob` / `hasBlob` / `borrowUrl` are now **local-first** (fixes the old dispatch that sent combined refs down the remote path); remote fallback **self-heals** by repopulating the local cache under the known hash.
- Opt-in `verifyRemoteHash`, a `withRemoteUrl(ref, url)` constructor, and hash-canonicalized identity so a combined ref and a local-only ref with the same hash dedup.

## Test evidence
- New unit coverage: deferred-cache mechanics (ordering, pending-after-eviction, flush drain, failure surfacing, coalescing, delete race), relaxed-schema validation, and blob-store combined-ref behaviors (local hit, remote fallback + repopulate, verify success/mismatch, `withRemoteUrl` validation, identity canonicalization).
- Full monorepo: `pnpm run lint`, `pnpm run typecheck`, and `pnpm test` all green (3225 tests pass).

## Related PRs
None.

## Jira
N/A — internal library refactor; no ticket.
