### PR TITLE
fix(data): correct version-upgrader self-service guidance + reject corrupt stamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/src/features/main/services/main-service/versioning/versions.ts
+++ b/packages/data-lit-todo/src/features/main/services/main-service/versioning/versions.ts
@@ -6,9 +6,9 @@
 //
 // HOW TO EVOLVE THIS FILE:
 //   • Change a component/resource schema in core-database, then run the tests.
-//   • If a test fails, it prints the exact entry to append here (and the new
-//     `databaseVersion` default to set in resources.ts). Do THAT — do not edit
-//     an existing entry.
+//   • If a test fails, it prints the exact entry to append here. Do THAT — do not
+//     edit an existing entry. `db.version` follows the history automatically
+//     (= entries.length - 1); there is no resource default to set.
 //   • Additive/minor changes need only the `changes` patch (no handler).
 //   • A change flagged BREAKING needs a `handler` (see the test's message).
 //

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/public/create-database.ts
+++ b/packages/data/src/ecs/database/public/create-database.ts
@@ -82,16 +82,20 @@ export function createDatabase(
 }
 
 // The per-quadrant schema versions a blob was saved at, from its save metadata.
-// Absent (a legacy blob predating versioning) ⇒ 0 for both quadrants. A present but
-// non-numeric stamp (a corrupt/hand-crafted blob) ⇒ +Infinity, so it is treated as
-// "newer than any app" and REJECTED rather than triggering a wrong full replay.
+// A blob predating versioning carries NO `schemaVersions` block at all ⇒ 0 for both
+// quadrants (legacy, full replay). But once the block is PRESENT, every stamp must be
+// a finite number: a missing/null/non-numeric stamp is a corrupt/hand-crafted blob ⇒
+// +Infinity, so it is treated as "newer than any app" and REJECTED rather than
+// silently triggering a wrong full replay from 0.
 function readSchemaVersions(data: unknown): { document: number; settings: number } {
     const meta = (data as { schemaVersions?: { document?: unknown; settings?: unknown } } | null)?.schemaVersions;
-    const read = (value: unknown): number => {
-        const n = Number(value ?? 0);
-        return Number.isFinite(n) ? n : Infinity;
-    };
-    return { document: read(meta?.document), settings: read(meta?.settings) };
+    if (meta === undefined || meta === null) {
+        return { document: 0, settings: 0 }; // legacy blob predating versioning
+    }
+    // A stamp must BE a finite number. `Number(null)` is 0, so coercion would let a
+    // corrupt null stamp masquerade as version 0 — check the type instead.
+    const read = (value: unknown): number => (typeof value === "number" && Number.isFinite(value) ? value : Infinity);
+    return { document: read(meta.document), settings: read(meta.settings) };
 }
 
 // Whether a persisted quadrant is covered by a load/save scope (undefined ⇒ both).

--- a/packages/data/src/ecs/database/versioning/assert-versions-match-schema.ts
+++ b/packages/data/src/ecs/database/versioning/assert-versions-match-schema.ts
@@ -223,7 +223,7 @@ function buildRecipe(drifts: Drift[], length: number): string {
     const breaking = drifts.filter((d) => d.kind === "breaking");
     const lines: string[] = [
         `The version history no longer matches the current schema — ${drifts.length} change(s) are unrecorded.`,
-        `Fix: append ONE new entry (version: ${length}) with the changes below, then set the version resource default to ${length}.`,
+        `Fix: append ONE new entry (version: ${length}) with the changes below — db.version follows the history automatically (= entries.length - 1); there is no resource default to set.`,
         ``,
     ];
 

--- a/packages/data/src/ecs/database/versioning/version-entry.ts
+++ b/packages/data/src/ecs/database/versioning/version-entry.ts
@@ -46,10 +46,20 @@ export type SchemaChanges = Readonly<Record<string, Patch<Schema> | undefined>>;
  *
  * `handler` is present **iff** the change is not automatically convertible (a
  * *major* change — a type change, split, cross-component move, …). It runs against
- * the document store already staged to the schema of version `i - 1` — the input
- * this entry transforms — so it sees a known shape for every component (no pinning
- * needed) and transforms the data in place. Additive / minor / removal changes
+ * the store staged to the schema of version `i - 1` — the input this entry
+ * transforms — and transforms the data in place. Additive / minor / removal changes
  * carry no handler — load-time conversion handles them.
+ *
+ * SINGLE-QUADRANT CONTRACT. A handler touches exactly ONE persisted quadrant —
+ * `document` (shared+persistent) or `settings` (nonShared+persistent): the one its
+ * schema change is in, which the guard enforces. Only THAT quadrant is staged to the
+ * version `i - 1` shape before the handler runs; the other quadrant is deliberately
+ * left unconformed, because per-quadrant versioning lets the two drift to different
+ * versions and staging the other one could down-convert it. So a handler must read
+ * and write ONLY its own quadrant's components/resources. Reading another quadrant is
+ * a silent bug: under a scoped/split load it may be absent or at a different version,
+ * so the read returns stale/default data and the migration decides wrong. This is not
+ * statically enforced — keep each handler within its own quadrant.
  */
 export type VersionEntry = {
     /**

--- a/packages/data/src/ecs/database/versioning/version-upgrader.per-quadrant.test.ts
+++ b/packages/data/src/ecs/database/versioning/version-upgrader.per-quadrant.test.ts
@@ -171,4 +171,37 @@ describe("per-quadrant upgrade through the full Database load path", () => {
         expect(result).toEqual({ loaded: false, currentVersion: 2, schemaVersions: { document: Infinity, settings: 2 } });
     });
 
+    it("rejects a null version stamp instead of replaying from 0", async () => {
+        const saved = mergedStore(xy, themeObj);
+        insertPos(saved, { x: 1, y: 2 });
+        const blob = { ...(saved.toData() as object), schemaVersions: { document: null, settings: 2 } };
+
+        const app = Database.create(
+            Database.Plugin.create({ components: { pos: xy, theme: themeObj }, resources: {}, archetypes: {} }),
+            { versioning: upgrader() },
+        );
+        const result = await app.fromData(blob);
+
+        // `Number(null)` is 0, so coercion would masquerade a corrupt null stamp as
+        // version 0 and replay everything. A PRESENT block requires a finite number,
+        // so a null stamp reads as +Infinity ⇒ reject (live db untouched).
+        expect(result).toEqual({ loaded: false, currentVersion: 2, schemaVersions: { document: Infinity, settings: 2 } });
+    });
+
+    it("rejects a present schemaVersions block that is missing a quadrant stamp", async () => {
+        const saved = mergedStore(xy, themeObj);
+        insertPos(saved, { x: 1, y: 2 });
+        const blob = { ...(saved.toData() as object), schemaVersions: { document: 1 } };
+
+        const app = Database.create(
+            Database.Plugin.create({ components: { pos: xy, theme: themeObj }, resources: {}, archetypes: {} }),
+            { versioning: upgrader() },
+        );
+        const result = await app.fromData(blob);
+
+        // Only a WHOLLY absent `schemaVersions` block is legacy (0/0, full replay). Once
+        // the block is present, an absent quadrant stamp is malformed ⇒ +Infinity ⇒ reject.
+        expect(result).toEqual({ loaded: false, currentVersion: 2, schemaVersions: { document: 1, settings: Infinity } });
+    });
+
 });


### PR DESCRIPTION
Small follow-up to the version-upgrader work (#184). Four issues surfaced in a post-merge re-review — three documentation/guidance fixes and one correctness hardening.

### Fixes

1. **Drift recipe misdirected toward the removed version resource** (`assert-versions-match-schema.ts`). The self-service recipe printed on schema drift still said *"then set the version resource default to N"* — but #184 removed that resource; `db.version` now derives from `entries.length - 1`. An agent/human obeying it would re-add a `databaseVersion` resource, which then registers as an untracked component and re-drifts the guard with no exclusion param left to escape. Dropped the clause (the doc rule already said "there is no resource default to update").

2. **data-lit-todo versioning template carried the same dead reference** — it's the file every versioned app copies from, so the stale line propagates.

3. **`readSchemaVersions` accepted a corrupt null/missing stamp as version 0** (`create-database.ts`). `Number(value ?? 0)` — and `Number(null) === 0` — meant a present-but-`null` (or absent) quadrant stamp read as version 0 and **silently triggered a full replay from 0** instead of rejecting. Now only a *wholly absent* `schemaVersions` block is legacy (0/0); once the block is present, each quadrant stamp must be a finite number or the load rejects non-destructively (live db untouched). Matches the existing non-numeric→reject contract. +2 tests (null stamp, missing quadrant stamp).

4. **`version-entry` handler doc overstated its guarantee.** It claimed the handler "sees a known shape for **every** component" — false under a scoped/split load, where `create-version-upgrader` stages **only the handler's own quadrant** (`pickQuadrant`). Documented the single-quadrant contract: a handler must read/write only its own quadrant; reading another returns stale/default data under a scoped load and decides the migration wrong. (A runtime read-guard would need store instrumentation on the live path, which we avoid — deferred as a separate option if split-persistence adoption grows.)

### Verification
- `pnpm -r run typecheck`, `pnpm run lint`, `@adobe/data build` — all clean.
- Versioning suite green (94 tests), including the two new corrupt-stamp cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)