### PR TITLE
fix(data): let blobStore's disk cache grow unbounded

### DIFF
--- a/packages/data/src/cache/blob-store.ts
+++ b/packages/data/src/cache/blob-store.ts
@@ -211,7 +211,9 @@ export function createBlobStore(options: BlobStoreOptions = {}) {
   const cachePromise = (): Promise<DeferredFallbackAsyncCache> =>
     (cachePromiseInternal ??= getDeferredManagedPersistentCache("blobstore", {
       maximumMemoryEntries: 10,
-      maximumStorageEntries: 1000,
+      // No storage-tier cap: local blob refs already self-heal from
+      // remoteBlobRef on eviction (see getBlob), so we rely on the browser's
+      // own Cache Storage eviction instead of a manual FIFO scan/trim.
     }));
 
   // Track borrowed URLs and their reference counts

--- a/packages/data/src/cache/get-persistent-cache.ts
+++ b/packages/data/src/cache/get-persistent-cache.ts
@@ -10,7 +10,14 @@ import { createMemoryAsyncCache } from "./memory-async-cache.js";
 
 interface ManagedCacheOptions {
   maximumMemoryEntries: number;
-  maximumStorageEntries: number;
+  /**
+   * Cap on the storage-tier entry count, enforced by periodically scanning
+   * and FIFO-trimming all keys in the underlying Cache Storage bucket. Omit
+   * to leave the storage tier unbounded and rely on the browser's own
+   * Cache Storage eviction (coarser-grained, but avoids the recurring
+   * full-bucket `keys()` scan this cap requires).
+   */
+  maximumStorageEntries?: number;
 }
 
 /**
@@ -39,10 +46,14 @@ async function createManagedTiers(
     createMemoryAsyncCache(),
     options.maximumMemoryEntries
   );
-  const storageCache = createManagedAsyncCache(
-    await getUnmanagedPersistentCache(name),
-    options.maximumStorageEntries
-  );
+  const unmanagedStorageCache = await getUnmanagedPersistentCache(name);
+  const storageCache =
+    options.maximumStorageEntries === undefined
+      ? unmanagedStorageCache
+      : createManagedAsyncCache(
+          unmanagedStorageCache,
+          options.maximumStorageEntries
+        );
   return { memoryCache, storageCache };
 }
 


### PR DESCRIPTION
## Summary
- Drops the manual FIFO cap on `blobStore`'s storage tier (was `maximumStorageEntries: 1000`), so the disk cache relies on the browser's own Cache Storage eviction instead of periodically scanning/sorting every key in the bucket.
- `maximumStorageEntries` is now optional on `getManagedPersistentCache`/`getDeferredManagedPersistentCache`; when omitted the storage tier skips the FIFO-trim wrapper entirely and uses the raw persistent cache.
- `datacache` (used by `data-cache.ts`) keeps its existing 1000-entry cap unchanged, since it has no remote-URL fallback for evicted entries the way `blobStore`'s combined refs do.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run typecheck` (clean, tsbuildinfo caches cleared first)
- [x] `pnpm test` in `packages/data` — full suite (275 files / 3229 tests) passes, including `blob-store.browser.test.ts` and `managed-async-cache.browser.test.ts`