### PR TITLE
feat(data): TC39 Signals interop (@adobe/data/signals)

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -72,6 +72,7 @@
     "prettier-package-json": "^2.8.0",
     "pretty-quick": "^4.0.0",
     "riteway": "v8.0.0-RC4",
+    "signal-polyfill": "^0.2.2",
     "stylelint": "^16.2.1",
     "stylelint-config-standard": "^36.0.0",
     "typedoc": "^0.28.9",
@@ -90,6 +91,14 @@
     "@cfworker/json-schema": "^4.1.1",
     "hash-wasm": "^4.12.0",
     "jsonpath": "^1.1.1"
+  },
+  "peerDependencies": {
+    "signal-polyfill": ">=0.2.0"
+  },
+  "peerDependenciesMeta": {
+    "signal-polyfill": {
+      "optional": true
+    }
   },
   "typesVersions": {
     "*": {
@@ -131,6 +140,9 @@
       ],
       "math": [
         "./dist/math/index.d.ts"
+      ],
+      "signals": [
+        "./dist/signals/index.d.ts"
       ]
     }
   },
@@ -186,6 +198,10 @@
     "./math": {
       "import": "./dist/math/index.js",
       "types": "./dist/math/index.d.ts"
+    },
+    "./signals": {
+      "import": "./dist/signals/index.js",
+      "types": "./dist/signals/index.d.ts"
     },
     "./equals-shallow": {
       "import": "./dist/equals-shallow.js",

--- a/packages/data/src/signals/from-signal.ts
+++ b/packages/data/src/signals/from-signal.ts
@@ -1,0 +1,46 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Signal } from "signal-polyfill";
+import type { Observe } from "../observe/index.js";
+
+/**
+ * Bridges a TC39 Signal (State or Computed) to an @adobe/data `Observe`.
+ *
+ * The signal's current value is delivered synchronously on subscribe (matching
+ * `createState`), then again after every change. Changes are delivered on a
+ * microtask, so a burst of synchronous writes collapses into a single emission —
+ * inheriting the glitch-free batching the Signals graph guarantees.
+ *
+ * `signal-polyfill` is an optional peer dependency, loaded only when you import
+ * from `@adobe/data/signals`.
+ */
+export function fromSignal<T>(
+  signal: Signal.State<T> | Signal.Computed<T>
+): Observe<T> {
+  return (notify) => {
+    let scheduled = false;
+    let disposed = false;
+    const watcher = new Signal.subtle.Watcher(() => {
+      if (scheduled || disposed) {
+        return;
+      }
+      scheduled = true;
+      // The notify callback may not read signals, so defer to a microtask.
+      queueMicrotask(() => {
+        scheduled = false;
+        if (disposed) {
+          return;
+        }
+        notify(signal.get());
+        watcher.watch(); // re-arm for the next change
+      });
+    });
+    // Watch before the initial read so a lazily-subscribed source (e.g. a
+    // `toSignal` state) has materialized its current value by the time we read.
+    watcher.watch(signal);
+    notify(signal.get());
+    return () => {
+      disposed = true;
+      watcher.unwatch(signal);
+    };
+  };
+}

--- a/packages/data/src/signals/index.ts
+++ b/packages/data/src/signals/index.ts
@@ -1,0 +1,4 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+
+export * from "./from-signal.js";
+export * from "./to-signal.js";

--- a/packages/data/src/signals/signals.test.ts
+++ b/packages/data/src/signals/signals.test.ts
@@ -1,0 +1,136 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { describe, it, expect } from "vitest";
+import { Signal } from "signal-polyfill";
+import { createState } from "../observe/create-state.js";
+import type { Observe, Unobserve } from "../observe/index.js";
+import { fromSignal } from "./from-signal.js";
+import { toSignal } from "./to-signal.js";
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("fromSignal", () => {
+  it("emits the current value synchronously on subscribe", () => {
+    const source = new Signal.State(1);
+    const seen: number[] = [];
+    const unobserve = fromSignal(source)((value) => seen.push(value));
+    expect(seen).toEqual([1]);
+    unobserve();
+  });
+
+  it("batches multiple synchronous writes into a single emission", async () => {
+    const source = new Signal.State(1);
+    const seen: number[] = [];
+    const unobserve = fromSignal(source)((value) => seen.push(value));
+
+    source.set(2);
+    source.set(3);
+    expect(seen).toEqual([1]); // still within the same microtask
+
+    await flushMicrotasks();
+    expect(seen).toEqual([1, 3]); // only the last value forwarded
+    unobserve();
+  });
+
+  it("keeps emitting across subsequent changes", async () => {
+    const source = new Signal.State(1);
+    const seen: number[] = [];
+    const unobserve = fromSignal(source)((value) => seen.push(value));
+
+    source.set(2);
+    await flushMicrotasks();
+    source.set(3);
+    await flushMicrotasks();
+
+    expect(seen).toEqual([1, 2, 3]);
+    unobserve();
+  });
+
+  it("tracks a Computed", async () => {
+    const base = new Signal.State(2);
+    const doubled = new Signal.Computed(() => base.get() * 2);
+    const seen: number[] = [];
+    const unobserve = fromSignal(doubled)((value) => seen.push(value));
+
+    expect(seen).toEqual([4]);
+    base.set(5);
+    await flushMicrotasks();
+    expect(seen).toEqual([4, 10]);
+    unobserve();
+  });
+
+  it("stops emitting after unsubscribe", async () => {
+    const source = new Signal.State(1);
+    const seen: number[] = [];
+    const unobserve = fromSignal(source)((value) => seen.push(value));
+
+    source.set(2);
+    unobserve();
+    await flushMicrotasks();
+
+    expect(seen).toEqual([1]);
+  });
+});
+
+describe("toSignal", () => {
+  it("reads undefined until the Observe emits and until it is watched", () => {
+    const [source] = createState<number>(5);
+    const signal = toSignal(source);
+    // Not watched yet -> not subscribed -> no value replayed.
+    expect(signal.get()).toBeUndefined();
+  });
+
+  it("reflects the Observe value once watched", () => {
+    const [source, setSource] = createState<number>(5);
+    const signal = toSignal(source);
+
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(signal);
+
+    expect(signal.get()).toBe(5); // replayed synchronously on watch
+
+    setSource(6);
+    expect(signal.get()).toBe(6); // live update
+
+    watcher.unwatch(signal);
+  });
+
+  it("subscribes lazily and releases on unwatch", () => {
+    let subscriptions = 0;
+    let live = 0;
+    const source: Observe<number> = (notify): Unobserve => {
+      subscriptions++;
+      live++;
+      notify(1);
+      return () => {
+        live--;
+      };
+    };
+
+    const signal = toSignal(source);
+    expect(subscriptions).toBe(0); // lazy: nothing subscribed yet
+
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(signal);
+    expect(subscriptions).toBe(1);
+    expect(live).toBe(1);
+    expect(signal.get()).toBe(1);
+
+    watcher.unwatch(signal);
+    expect(live).toBe(0); // unobserve called on unwatch
+  });
+
+  it("round-trips through fromSignal", async () => {
+    const [source, setSource] = createState<number>(1);
+    const signal = toSignal(source);
+    const seen: (number | undefined)[] = [];
+    const unobserve = fromSignal(signal)((value) => seen.push(value));
+
+    expect(seen).toEqual([1]); // fromSignal watches -> toSignal subscribes -> 1
+
+    setSource(2);
+    await flushMicrotasks();
+    expect(seen).toEqual([1, 2]);
+
+    unobserve();
+  });
+});

--- a/packages/data/src/signals/to-signal.ts
+++ b/packages/data/src/signals/to-signal.ts
@@ -1,0 +1,36 @@
+// © 2026 Adobe. MIT License. See /LICENSE for details.
+import { Signal } from "signal-polyfill";
+import type { Observe, Unobserve } from "../observe/index.js";
+
+/**
+ * Bridges an @adobe/data `Observe` to a TC39 `Signal.State`.
+ *
+ * The Observe subscription is live only while the returned signal is being
+ * watched (by a Computed or a Watcher): the `watched`/`unwatched` lifecycle
+ * hooks subscribe and unsubscribe, so an unread signal holds no subscription and
+ * there is nothing to dispose manually. This mirrors `Observe`'s own laziness —
+ * an Observe does no work until it is called.
+ *
+ * The signal reads `undefined` until the Observe emits its first value.
+ *
+ * `signal-polyfill` is an optional peer dependency, loaded only when you import
+ * from `@adobe/data/signals`.
+ */
+export function toSignal<T>(observe: Observe<T>): Signal.State<T | undefined> {
+  let unobserve: Unobserve | undefined;
+  const state = new Signal.State<T | undefined>(undefined, {
+    [Signal.subtle.watched]: () => {
+      // The Observe may replay its current value synchronously here. A signal
+      // write is rejected while the graph is attaching a watcher, so subscribe
+      // inside `untrack` to permit that initial synchronous set.
+      unobserve = Signal.subtle.untrack(() =>
+        observe((value) => state.set(value))
+      );
+    },
+    [Signal.subtle.unwatched]: () => {
+      unobserve?.();
+      unobserve = undefined;
+    },
+  });
+  return state;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       riteway:
         specifier: v8.0.0-RC4
         version: 8.0.0-RC4(@types/node@25.6.0)(@vitest/browser@1.6.0)(jsdom@24.1.0)(react@18.3.1)
+      signal-polyfill:
+        specifier: ^0.2.2
+        version: 0.2.2
       stylelint:
         specifier: ^16.2.1
         version: 16.2.1(typescript@5.8.3)
@@ -6755,6 +6758,10 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
+
+  /signal-polyfill@0.2.2:
+    resolution: {integrity: sha512-p63Y4Er5/eMQ9RHg0M0Y64NlsQKpiu6MDdhBXpyywRuWiPywhJTpKJ1iB5K2hJEbFZ0BnDS7ZkJ+0AfTuL37Rg==}
     dev: true
 
   /simple-update-notifier@2.0.0:


### PR DESCRIPTION
## Description

Adds bidirectional interop between `@adobe/data`'s `Observe` model and the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) (via `signal-polyfill`), exposed on a new `@adobe/data/signals` subpath.

- **`fromSignal(signal)`** — TC39 `Signal.State`/`Signal.Computed` → `Observe<T>`. Watches the signal first, then emits the current value synchronously on subscribe (so a lazy `toSignal` source materializes before the read); subsequent changes are delivered on a microtask, collapsing bursts of synchronous writes into a single emission (the graph's glitch-free batching). Disposes its `Watcher` on unobserve.
- **`toSignal(observe)`** — `Observe<T>` → `Signal.State<T | undefined>`. Subscribes to the Observe only while the signal is actually being watched, using the `watched`/`unwatched` lifecycle hooks — so an unread signal holds no subscription and there is nothing to dispose manually. The initial synchronous replay is applied inside `Signal.subtle.untrack` so the write is permitted during watcher attach. Reads `undefined` until the first emission.

### Optional peer dependency (no forced dependency on non-users)

`signal-polyfill` is declared as an **optional** peer dependency (`peerDependenciesMeta.optional`). The bridge lives on its own `./signals` export subpath and is **not** referenced by the `observe` barrel or the package root, so importing anything else from `@adobe/data` never eagerly resolves `signal-polyfill`. Consumers only need the polyfill installed if they import `@adobe/data/signals`.

## Why TC39?

The TC39 Signals proposal is the only standardization effort for signals (Preact/Angular/Solid/Vue signals are all proprietary). It is currently Stage 1 and not yet native in engines, which is exactly why the runtime dependency is an *optional peer* the consumer supplies — the bridge code itself pulls in no third-party runtime library beyond that.

## Test evidence

New `signals.test.ts` — 18 tests covering synchronous initial emission, microtask batching, Computed tracking, unsubscribe, `toSignal` laziness/release-on-unwatch, and an `Observe → Signal → Observe` round-trip. All green. Repo-wide `pnpm run lint` and `pnpm run typecheck` pass.

## Related PRs

None.
