### PR TITLE
fix(data): keep resource observers/writes valid across store reload; end nonPersistent strip loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu-hopper/package.json
+++ b/packages/data-gpu-hopper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-hopper",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Hopper sample - real-time ECS game rendered as colored cubes via @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu-samples/package.json
+++ b/packages/data-gpu-samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-gpu-samples",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "WebGPU samples built on @adobe/data-gpu",
   "type": "module",
   "private": true,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit-space-rock-game/package.json
+++ b/packages/data-lit-space-rock-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-space-rock-game",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Space Rock Game sample - real-time ECS game with Lit and @adobe/data",
   "type": "module",
   "private": true,

--- a/packages/data-lit-tictactoe/package.json
+++ b/packages/data-lit-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-tictactoe",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Tic-Tac-Toe sample - Lit web components with @adobe/data-lit and AgenticService",
   "type": "module",
   "private": true,

--- a/packages/data-lit-todo/package.json
+++ b/packages/data-lit-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-lit-todo",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Todo application - Lit web components with @adobe/data ECS",
   "type": "module",
   "private": true,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-p2p-tictactoe/package.json
+++ b/packages/data-p2p-tictactoe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-p2p-tictactoe",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Serverless P2P tic-tac-toe — WebRTC DataChannel + @adobe/data-sync",
   "type": "module",
   "private": true,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react-hello/package.json
+++ b/packages/data-react-hello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-hello",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Hello World sample - click counter using @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react-pixie/package.json
+++ b/packages/data-react-pixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-react-pixie",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "PixiJS React sample - ECS sprites (bunny, fox) with @adobe/data-react",
   "type": "module",
   "private": true,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid-dashboard/package.json
+++ b/packages/data-solid-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-solid-dashboard",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Mini dashboard sample — multiple components sharing one @adobe/data ECS database with SolidJS",
   "type": "module",
   "private": true,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/ecs/database/observed/create-observed-database.test.ts
+++ b/packages/data/src/ecs/database/observed/create-observed-database.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { createObservedDatabase } from "./create-observed-database.js";
 import { Store } from "../../store/index.js";
 import { Schema } from "../../../schema/index.js";
+import { Observe } from "../../../observe/index.js";
 import { Entity } from "../../entity/entity.js";
 import { Database } from "../database.js";
 
@@ -717,6 +718,139 @@ describe("createObservedDatabase", () => {
 
         unsubscribe();
         newUnsubscribe();
+    });
+
+    // A nonPersistent (transient) resource with a non-null array default, added
+    // via `extend` AFTER the nonPersistent quadrant is already occupied by
+    // presence entities. That makes the resource singleton land on a HIGH entity
+    // id. A whole-database `fromData` / `reset` resets the nonPersistent quadrant
+    // (counter back to 0) and re-seeds the singleton under a FRESH, LOWER id — so
+    // anything that captured the original id is now looking at a dangling entity.
+    const createTransientResourceFixture = () => {
+        const restrictedUrlsSchema = {
+            type: "array",
+            items: { type: "string" },
+            default: [] as readonly string[],
+            nonPersistent: true,
+        } as const satisfies Schema;
+
+        const store = Store.create({
+            components: { cursor: { type: "number" } },
+            resources: {},
+            // Presence carries the nonPersistent marker → nonPersistent quadrant.
+            archetypes: { Presence: ["cursor", "nonPersistent"] } as const,
+        });
+        const observed = createObservedDatabase(store);
+
+        // Occupy the nonPersistent quadrant so the resource singleton (added
+        // next) does not land on that quadrant's id 0.
+        for (let i = 0; i < 4; i++) {
+            observed.execute(db => db.archetypes.Presence.insert({ cursor: i, nonPersistent: true }));
+        }
+
+        // `ObservedDatabase.extend` returns `any` at runtime; bridge that untyped
+        // return to the small surface these tests exercise (one boundary cast).
+        interface TransientResourceDb {
+            observe: { resources: { restrictedUrls: Observe<readonly string[]> } };
+            resources: { restrictedUrls: readonly string[] };
+            execute(handler: (t: { resources: { restrictedUrls: readonly string[] } }) => void): unknown;
+            toData(): unknown;
+            fromData(data: unknown): void;
+            reset(): void;
+        }
+        const db = observed.extend(Database.Plugin.create({
+            resources: { restrictedUrls: restrictedUrlsSchema },
+        })) as unknown as TransientResourceDb;
+        return { db };
+    };
+
+    it("should re-emit a transient resource's schema default (not null) on fromData reload", () => {
+        const { db } = createTransientResourceFixture();
+
+        const observer = vi.fn();
+        const unsubscribe = db.observe.resources.restrictedUrls(observer);
+
+        // Initial emit is the default.
+        expect(observer).toHaveBeenLastCalledWith([]);
+        observer.mockClear();
+
+        db.fromData(db.toData());
+
+        // After fromData the observer must fire with the [] default, never null.
+        expect(observer).toHaveBeenCalledTimes(1);
+        expect(observer).toHaveBeenLastCalledWith([]);
+
+        // A live subscriber relying on the array type must not receive null.
+        const lastValue: readonly string[] | null = observer.mock.calls.at(-1)?.[0];
+        expect(lastValue).not.toBeNull();
+        expect(() => lastValue!.includes("x")).not.toThrow();
+
+        unsubscribe();
+    });
+
+    it("should re-emit a transient resource's schema default (not null) on reset", () => {
+        const { db } = createTransientResourceFixture();
+
+        const observer = vi.fn();
+        const unsubscribe = db.observe.resources.restrictedUrls(observer);
+        observer.mockClear();
+
+        db.reset();
+
+        expect(observer).toHaveBeenCalledTimes(1);
+        expect(observer).toHaveBeenLastCalledWith([]);
+
+        unsubscribe();
+    });
+
+    it("should allow writing a transient resource after a fromData reload", () => {
+        const { db } = createTransientResourceFixture();
+
+        db.fromData(db.toData());
+
+        // The transactional resource setter must resolve the singleton's CURRENT
+        // id, not the id captured at construction — otherwise this throws
+        // "Entity not found".
+        const observer = vi.fn();
+        const unsubscribe = db.observe.resources.restrictedUrls(observer);
+        observer.mockClear();
+
+        expect(() => db.execute(t => { t.resources.restrictedUrls = ["x"]; })).not.toThrow();
+        expect(db.resources.restrictedUrls).toEqual(["x"]);
+        // The write must also propagate through the (component-notification) path.
+        expect(observer).toHaveBeenLastCalledWith(["x"]);
+
+        unsubscribe();
+    });
+
+    it("should re-emit the LOADED value (not a stale one) for a persistent resource on fromData", () => {
+        // Regression guard: the resource observer must read the singleton live
+        // through the archetype, not a captured column. `archetype.fromData`
+        // replaces `archetype.columns` wholesale, so a persistent resource whose
+        // value changes across the load must re-emit the LOADED value.
+        const configSchema = { type: "number", default: 0 } as const satisfies Schema;
+        const make = () => createObservedDatabase(Store.create({
+            components: {},
+            resources: { config: configSchema },
+            archetypes: {} as const,
+        }));
+
+        const source = make();
+        source.execute(db => { db.resources.config = 42; });
+        const snapshot = source.toData();
+
+        const target = make();
+        const observer = vi.fn();
+        const unsubscribe = target.observe.resources.config(observer);
+        expect(observer).toHaveBeenLastCalledWith(0); // pre-load default
+        observer.mockClear();
+
+        target.fromData(snapshot);
+
+        expect(observer).toHaveBeenCalledTimes(1);
+        expect(observer).toHaveBeenLastCalledWith(42);
+
+        unsubscribe();
     });
 
     it("should extend with new components, resources, and archetypes", () => {

--- a/packages/data/src/ecs/database/observed/create-observed-database.ts
+++ b/packages/data/src/ecs/database/observed/create-observed-database.ts
@@ -125,12 +125,33 @@ export function createObservedDatabase<
         return names;
     };
 
+    // The resource singleton is always row 0 of its identity-stable archetype.
+    // Bind the observer to the resource COMPONENT's change notifications and read
+    // row 0 live, rather than capturing the singleton's entity id: fromData/reset
+    // re-creates the singleton under a fresh id, so a fixed-id observer would be
+    // stranded on a dangling entity (and emit null). The archetype instance and
+    // the row-0 convention both survive the reload, so a live read always yields
+    // the current value — including the schema default just re-seeded.
+    const observeResourceValue = <K extends StringKeyof<R>>(resource: K): Observe<R[K]> => {
+        const archetype = store.ensureArchetype(resourceArchetypeComponents(resource));
+        // Read the singleton (row 0) through the archetype on every call, never a
+        // captured column: `archetype.fromData` replaces `archetype.columns`
+        // wholesale on load, so a captured column would detach and re-emit the
+        // pre-reload value. The archetype instance itself is identity-stable.
+        // Runtime invariant: a resource is stored as a component column of the
+        // same name on its singleton archetype — outside the C-typed columns view.
+        // Re-read `archetype.columns` (not a captured columns object) each call:
+        // `Object.assign(archetype, data)` swaps the whole object on load.
+        const read = () =>
+            (archetype.columns as unknown as Record<string, { get(row: number): R[K] }>)[resource]!.get(0);
+        return (observer) => {
+            observer(read());
+            return addToMapSet(resource as unknown as StringKeyof<C>, componentObservers)(() => observer(read()));
+        };
+    };
+
     const observeResource = Object.fromEntries(
-        Object.entries(store.resources).map(([resource]) => {
-            const archetype = store.ensureArchetype(resourceArchetypeComponents(resource));
-            const resourceId = archetype.columns[ID].get(0);
-            return [resource, Observe.withMap(observeEntity(resourceId), (values) => (values as any)?.[resource] ?? null)];
-        })
+        Object.keys(store.resources).map((resource) => [resource, observeResourceValue(resource as StringKeyof<R>)])
     ) as { [K in StringKeyof<R>]: Observe<R[K]>; };
 
     const observeTransaction: Observe<TransactionResult<C>> = (notify: (transaction: TransactionResult<C>) => void) => {
@@ -188,11 +209,7 @@ export function createObservedDatabase<
     const rebuildObservableMaps = () => {
         (observe as any).components = mapEntries(store.componentSchemas, ([component]) => addToMapSet(component, componentObservers));
         (observe as any).resources = Object.fromEntries(
-            Object.entries(store.resources).map(([resource]) => {
-                const archetype = store.ensureArchetype(resourceArchetypeComponents(resource));
-                const resourceId = archetype.columns[ID].get(0);
-                return [resource, Observe.withMap(observeEntity(resourceId), (values) => (values as any)?.[resource] ?? null)];
-            })
+            Object.keys(store.resources).map((resource) => [resource, observeResourceValue(resource as StringKeyof<R>)])
         );
     };
 

--- a/packages/data/src/ecs/database/transactional-store/create-transactional-store.ts
+++ b/packages/data/src/ecs/database/transactional-store/create-transactional-store.ts
@@ -187,11 +187,14 @@ export function createTransactionalStore<
         const resourceId = name as keyof C;
         const componentNames = resourceComponentNames(name);
         const archetype = store.ensureArchetype(componentNames);
-        const entityId = archetype.columns[ID].get(0);
         Object.defineProperty(resources, name, {
             get: Object.getOwnPropertyDescriptor(store.resources, name)!.get,
             set: (newValue) => {
-                updateEntity(entityId, { [resourceId]: newValue } as any);
+                // Resolve the singleton's CURRENT id at write time: fromData/reset
+                // re-creates the resource singleton under a fresh id, so an id
+                // captured here would go stale (row 0 of this archetype is always
+                // the singleton).
+                updateEntity(archetype.columns[ID].get(0), { [resourceId]: newValue } as any);
             },
             enumerable: true,
             // Configurable so pruneToSchema can drop a retired resource's accessor
@@ -310,11 +313,13 @@ export function createTransactionalStore<
                     const resourceId = name as keyof C;
                     const componentNames = resourceComponentNames(name);
                     const archetype = store.ensureArchetype(componentNames);
-                    const entityId = archetype.columns[ID].get(0);
                     Object.defineProperty(resources, name, {
                         get: Object.getOwnPropertyDescriptor(store.resources, name)!.get,
                         set: (newValue: any) => {
-                            updateEntity(entityId, { [resourceId]: newValue } as any);
+                            // Resolve the singleton's CURRENT id at write time (see
+                            // the initial resource loop above) — a captured id goes
+                            // stale across a fromData/reset re-create.
+                            updateEntity(archetype.columns[ID].get(0), { [resourceId]: newValue } as any);
                         },
                         enumerable: true,
                         configurable: true,

--- a/packages/data/src/ecs/store/core/create-core.ts
+++ b/packages/data/src/ecs/store/core/create-core.ts
@@ -484,8 +484,12 @@ export function createCore<NC extends ComponentSchemas>(
             for (const archetype of restored) {
                 const present = [...noDefault].filter((n) => archetype.components.has(n));
                 if (present.length === 0) continue;
-                const removal = Object.fromEntries(present.map((n) => [n, undefined])) as EntityUpdateValues<C>;
                 while (archetype.rowCount > 0) {
+                    // A FRESH removal object per pass: core.update deletes the
+                    // `undefined` keys from the object it is handed (reusing it as
+                    // the migrated row's data), so a shared object would empty out
+                    // after the first row and the loop would never terminate.
+                    const removal = Object.fromEntries(present.map((n) => [n, undefined])) as EntityUpdateValues<C>;
                     updateEntity(archetype.columns[ID]!.get(0), removal);
                 }
             }

--- a/packages/data/src/ecs/store/public/create-store.test.ts
+++ b/packages/data/src/ecs/store/public/create-store.test.ts
@@ -763,6 +763,35 @@ describe("createStore", () => {
             expect(target.read(selectionEntity)).toBeNull();
         });
 
+        it("strips a no-default nonPersistent component from every restored row without hanging", { timeout: 3000 }, () => {
+            // A PERSISTENT entity archetype carrying a nonPersistent-schema
+            // component that has NO default (the GPU-buffer / handle pattern).
+            // On load the column is rebuilt empty and the component must be
+            // stripped from EVERY row. With 2+ such rows the strip loop must
+            // still terminate — a shared removal object emptied by the first
+            // pass would loop forever (mirrors pruneToSchema's fresh-per-pass fix).
+            const makeStore = () => createStore({
+                components: {
+                    x: { type: "number", default: 0 },
+                    handle: { type: "number", nonPersistent: true },
+                },
+                resources: {},
+                archetypes: { Buffered: ["x", "handle"] },
+            } as const);
+
+            const source = makeStore();
+            source.archetypes.Buffered.insert({ x: 0, handle: 111 });
+            source.archetypes.Buffered.insert({ x: 1, handle: 222 });
+            const snapshot = source.toData({ copy: true });
+
+            const target = makeStore();
+            target.fromData(snapshot);
+
+            // Both rows survive with `handle` stripped (migrated to the x-only archetype).
+            expect(target.count(["x"])).toBe(2);
+            expect(target.count(["handle"])).toBe(0);
+        });
+
         it("preserves archetype ids across serialization when a nonPersistent archetype precedes a persistent one", () => {
             const selectionSchema = { type: "boolean", default: false } as const satisfies Schema;
             const positionScalarSchema = { type: "number", default: 0 } as const satisfies Schema;


### PR DESCRIPTION
## Description

Fixes a family of bugs around **resource singletons and store reload**. A resource is stored as the single entity (row 0) of an archetype `[id, <name>, nonPersistent?]`. Its **entity id was captured** at subscribe/construction time, but a whole-database `fromData` or `reset()` re-creates the singleton under a **fresh id** (the nonPersistent quadrant's id counter is reset to 0). Anything holding the old id then points at a dangling entity. This only surfaces when the singleton was *not* the first entity in its quadrant — e.g. a transient resource added via `extend` after presence/cursor entities already occupied the nonPersistent quadrant.

Four defects, three sharing that root cause:

1. **`observe.resources.X` emits `null` after `fromData`** (the reported bug). A live `restrictedUrls.includes(url)` then throws `TypeError: Cannot read properties of null`.
2. Same `null` after **`reset()`**.
3. **Infinite loop** in `reconstructNonPersistentColumns` (the load-time strip path for a `nonPersistent`-schema component with **no default**, e.g. the GPU-buffer/handle pattern): the `removal` object was built once and reused, but `core.update` mutates it (deletes `undefined` keys to reuse as the migrated row's data). After the first strip it becomes `{}`, so every later update is a no-op and `rowCount` never reaches 0 — hangs whenever a restored persistent archetype has 2+ such rows. (Independent of the id bug.)
4. The **transactional resource setter** threw `Entity not found` after a reload — it too captured the singleton id.

### Fixes (all in `packages/data/src`)

- `ecs/database/observed/create-observed-database.ts` — resource observers now bind to the resource **component**'s change notifications and read row 0 **live through the identity-stable archetype** (never a captured id or column). Reading through `archetype.columns` each call is required because `archetype.fromData` replaces the whole `columns` object on load.
- `ecs/database/transactional-store/create-transactional-store.ts` — the setter resolves `archetype.columns[ID].get(0)` at **write time** (both the initial loop and the `extend` sync).
- `ecs/store/core/create-core.ts` — `reconstructNonPersistentColumns` rebuilds `removal` **per pass**, matching the existing `pruneToSchema` guard.

### Behavior note

Resource writes that reassign the **identical reference** (`db.resources.x = sameRef`) no longer re-emit — the component-notification path dedups no-op writes (guarded by `newValue !== oldValue`). All genuine writes still emit exactly once per transaction. This matches the codebase's `withDeduplicateData` philosophy; deliberate.

## Test evidence

New pinning tests (each fails on the pre-fix code):
- `create-observed-database.test.ts` — transient resource re-emits `[]` (not null) on `fromData` and on `reset`; write-after-reload succeeds and propagates to observers; **persistent** resource re-emits the *loaded* value after `fromData` (regression guard for the archetype column-swap).
- `create-store.test.ts` — a no-default `nonPersistent` component is stripped from 2+ restored rows without hanging (explicit `timeout`).

```
data suite:            3239 passed
monorepo typecheck:    all packages Done (tsbuildinfo cleared)
lint:                  clean
```

## Review

Reviewed by a separate model pass. It caught a real regression I introduced (M1): the first cut of the observer helper captured the *column* instance, which `archetype.fromData` swaps out via `Object.assign`, so a **persistent** resource re-emitted a stale pre-reload value. Fixed by reading through `archetype.columns` fresh each call, plus a dedicated regression test. Minor dedup behavior change accepted consciously (above); nits addressed (explicit test timeout, observer assertion on write-after-reload).

## Related PRs

None.

## Checklist

- [x] Tests added/updated — new pinning tests for all four defects + the persistent-resource regression guard.
- [x] Types pass — clean monorepo `typecheck` (tsbuildinfo cleared).
- [x] Lint passes.
- [x] Jira ticket — N/A (no ticket; reported informally).
