### PR TITLE
fix(data): ToType deep-plugin stack-depth (TS2321) + decouple createLazy gate from IsValid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-monorepo",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/packages/data-ai/.claude-plugin/plugin.json
+++ b/packages/data-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adobe-data-ai",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Architecture skills for @adobe/data — data-oriented modelling, archetype iteration, hot-path performance, and related conventions.",
   "author": {
     "name": "Adobe"

--- a/packages/data-ai/package.json
+++ b/packages/data-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-ai",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Cross-agent architecture skills for @adobe/data — installable as a Claude Code plugin or copied into any Agent-Skills-compatible agent (Cursor, Codex).",
   "type": "module",
   "private": false,

--- a/packages/data-gpu/package.json
+++ b/packages/data-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-gpu",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Adobe data WebGPU plugins and types for graphics and compute",
   "type": "module",
   "private": false,

--- a/packages/data-lit/package.json
+++ b/packages/data-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-lit",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Adobe data Lit bindings - hooks, elements, decorators",
   "type": "module",
   "private": false,

--- a/packages/data-persistence/package.json
+++ b/packages/data-persistence/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-persistence",
-    "version": "0.10.7",
+    "version": "0.10.8",
     "description": "Worker-based incremental persistence layer for @adobe/data ECS over OPFS (browser) and node:fs (server).",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-react/package.json
+++ b/packages/data-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-react",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Adobe data React bindings — hooks and context for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-solid/package.json
+++ b/packages/data-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-solid",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Adobe data SolidJS bindings — context and provider for ECS database",
   "type": "module",
   "private": false,

--- a/packages/data-sync/package.json
+++ b/packages/data-sync/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/data-sync",
-    "version": "0.10.7",
+    "version": "0.10.8",
     "description": "Multi-user real-time synchronisation for @adobe/data ECS — server, client, and in-process loopback.",
     "type": "module",
     "sideEffects": false,

--- a/packages/data-testing/package.json
+++ b/packages/data-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data-testing",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Conformance-testing utilities (Match + Conformance runners) for @adobe/data ECS features",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/data",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Adobe data oriented programming library",
   "type": "module",
   "sideEffects": false,

--- a/packages/data/src/schema/to-type.ts
+++ b/packages/data/src/schema/to-type.ts
@@ -29,14 +29,6 @@ type FromSchemaInternal<T, Depth extends number = 5> = T extends { const: infer 
   ? null
   : T extends { type: 'blob' }
   ? Blob
-  : T extends { type: 'observe' }
-  ? Observe<ToType<ValueSchema<T>, Decrement<Depth>>>
-  : T extends { type: 'promise' }
-  ? Promise<ToType<ValueSchema<T>, Decrement<Depth>>>
-  : T extends { type: 'generator' }
-  ? AsyncGenerator<ToType<ValueSchema<T>, Decrement<Depth>>>
-  : T extends { type: 'function' }
-  ? FromSchemaFunction<T, Decrement<Depth>>
   : T extends { type: 'typed-buffer', items: infer Items }
   ? TypedBuffer<FromSchemaInternal<Items>>
   : T extends { type: 'typed-buffer' }
@@ -46,6 +38,20 @@ type FromSchemaInternal<T, Depth extends number = 5> = T extends { const: infer 
   : T extends { type?: undefined, default: infer D } ? D
   : T extends { type: 'object' } | { properties: any }
   ? FromSchemaObject<T, Decrement<Depth>>
+  // Type-constructor schemas are placed AFTER the data branches on purpose: a
+  // data schema (every ECS component/resource) must NOT pay extra conditional
+  // depth for these, because `FromSchemas` runs `ToType` per component across a
+  // whole plugin `combine` chain, and the added depth tips deep chains past TS's
+  // stack-depth limit (TS2321). Only observe/promise/generator/function schemas —
+  // which appear in service schemas, never in the Plugin hot path — fall through.
+  : T extends { type: 'observe' }
+  ? Observe<ToType<ValueSchema<T>, Decrement<Depth>>>
+  : T extends { type: 'promise' }
+  ? Promise<ToType<ValueSchema<T>, Decrement<Depth>>>
+  : T extends { type: 'generator' }
+  ? AsyncGenerator<ToType<ValueSchema<T>, Decrement<Depth>>>
+  : T extends { type: 'function' }
+  ? FromSchemaFunction<T, Decrement<Depth>>
   : any
   ;
 

--- a/packages/data/src/service/async-data-service/create-lazy.test.ts
+++ b/packages/data/src/service/async-data-service/create-lazy.test.ts
@@ -205,6 +205,29 @@ const validWithPreload = createLazy({
   preload: true
 });
 
+// ✅ Test 4c: a service that is NOT a valid AsyncDataService (returns non-Data)
+// is still accepted — createLazy gates on schema-match alone, not IsValid.
+interface NonConformantService extends Service {
+  fetch: (id: string) => Promise<Response>;      // Response ∉ Data → not IsValid
+  count: Observe<number | undefined>;            // undefined-in-Observe → not IsValid
+}
+// The service genuinely fails IsValid...
+// @ts-expect-error - NonConformantService returns non-Data / undefined-in-Observe
+type _NonConformantFailsIsValid = Assert<IsValid<NonConformantService>>;
+// ...yet createLazy accepts it because the schema correctly describes the members.
+const validNonConformant = createLazy({
+  load: () => Promise.resolve({} as NonConformantService),
+  schema: {
+    type: "object",
+    properties: {
+      fetch: { type: "function", signature: { parameters: [{}], returns: { type: "promise", value: {} } } },
+      count: { type: "observe", value: {} }
+    },
+    required: ["fetch", "count"],
+    additionalProperties: false
+  }
+});
+
 // ============================================================================
 // ERROR TESTS (These should produce TypeScript errors)
 // ============================================================================

--- a/packages/data/src/service/async-data-service/create-lazy.ts
+++ b/packages/data/src/service/async-data-service/create-lazy.ts
@@ -3,7 +3,7 @@
 import { Observe } from "../../observe/index.js";
 import { Schema } from "../../schema/index.js";
 import { Service } from "../service.js";
-import { IsValidWithCompleteSchema } from "./is-valid-with-complete-schema.js";
+import { EquivalentTypes } from "../../types/types.js";
 
 // ============================================================================
 // TYPE INFERENCE HELPERS
@@ -37,6 +37,16 @@ type LazyMemberSchema =
 type LazyServiceSchema = Schema & {
   readonly properties?: { readonly [name: string]: LazyMemberSchema };
 };
+
+// createLazy's gate: the schema must completely and correctly describe the loaded
+// service's members. This is the actual correctness condition for building the
+// wrappers, and it is INTENTIONALLY independent of `AsyncDataService.IsValid` —
+// createLazy wraps whatever the schema describes, so a service that returns
+// non-`Data` (e.g. a `fetch(): Promise<Response>` port) can still be lazily
+// chunk-loaded as long as its schema matches. Enforce `IsValid` separately at the
+// service's definition site if you also want async-data-service conformance.
+type SchemaMatchesService<T extends Service, S extends Schema> =
+  EquivalentTypes<Schema.ToType<S>, Omit<T, keyof Service>>;
 
 // ============================================================================
 // RUNTIME WRAPPER KIND
@@ -87,7 +97,11 @@ function memberKind(member: Schema): WrapKind {
  *
  * TypeScript enforces that `schema` describes every member of the loaded service
  * with the correct wrapper kind; otherwise the `schema` argument fails to type-check
- * with a `__createLazyError` marker. Note: member value/parameter schemas authored as `{}`
+ * with a `__createLazyError` marker. This is the ONLY requirement — createLazy does
+ * NOT require the service to be a valid `AsyncDataService`, so a service that returns
+ * non-`Data` (e.g. `Promise<Response>`) can still be lazily loaded. Enforce
+ * `AsyncDataService.IsValid` separately at the service definition site if you want it.
+ * Note: member value/parameter schemas authored as `{}`
  * resolve to `any`, so presence and wrapper kind are checked but inner payload
  * types are only verified where a precise `value`/parameter schema is supplied.
  *
@@ -117,7 +131,7 @@ export function createLazy<
     load: LoadFn,
     schema: S,
     preload?: boolean
-  } & (IsValidWithCompleteSchema<InferService<LoadFn>, S> extends true
+  } & (SchemaMatchesService<InferService<LoadFn>, S> extends true
     ? unknown
     // Inline (not a named type) so the mismatch marker isn't a documented symbol.
     : { schema: { readonly __createLazyError: "createLazy: schema must completely and correctly describe the loaded service" } })


### PR DESCRIPTION
## Description

Follow-up to #193, two independent fixes for 0.10.8.

### Fix 1 — `Schema.ToType` deep-plugin stack depth (TS2321 regression)

#193 inserted the four type-constructor branches (`observe`/`promise`/`generator`/`function`) **before** the data branches in `Schema.ToType`. `FromSchemas` runs `ToType` per component, and `ToDatabase`/`FromPlugin` resolve that across an entire plugin `combine` chain — so every data-schema `ToType` now evaluated 4 extra conditionals deeper. On a chain already near TypeScript's stack-depth ceiling (the `Database.Plugin.combine` / TS2589 family), that tipped it into **`TS2321` "excessive stack depth"**. A downstream deep-plugin consumer hit it; `@adobe/data-lit`'s own deep chain builds clean on 0.10.6 but not 0.10.7.

**Fix:** move the constructor branches to **after** the data branches. Data schemas — every ECS component/resource, the Plugin hot path — return to the exact pre-#193 conditional-nesting depth; only service schemas (never in that path) fall through. No behavior change (to-type tests unchanged); it's purely a nesting-order fix. Verified against the consumer's live repro: the TS2321 errors clear.

### Fix 2 — decouple `createLazy` gate from `IsValid`

**Before:** `createLazy` required the loaded service to be a valid `AsyncDataService` *and* the schema to describe it (`IsValidWithCompleteSchema`). **After:** it gates on the schema-match alone — `EquivalentTypes<Schema.ToType<S>, members>`, the actual correctness condition for building the wrappers.

### Why

The `IsValid` precondition is orthogonal to what `createLazy` needs. The runtime iterates `schema.properties` and builds a wrapper per member from its schema `type`/`returns`; it never cares whether the service is a well-formed async-data-service. Coupling the two rejected services that legitimately need lazy chunk-loading but can't be `IsValid` — chiefly ports that return non-`Data`, e.g. `fetch(): Promise<Response>` (raw `Response` for streaming/auth headers is a real requirement; `Response` isn't `Data`). A downstream consumer hit exactly this migrating to the new API.

It also removes a confusing failure mode: previously an `IsValid` failure and a schema mismatch produced the **same** `__createLazyError`, sending consumers chasing schema/param issues when the real cause was the service interface. Now there is one failure mode — the schema doesn't match.

### What changed

- `createLazy`'s gate is now `SchemaMatchesService<T, S> = EquivalentTypes<Schema.ToType<S>, Omit<T, keyof Service>>` (no `IsValid` precondition). The `LazyMemberSchema` constraint (observe/function members only) is unchanged.
- `AsyncDataService.IsValid` / `IsValidWith{Partial,Complete}Schema` are unchanged — async-data-service conformance stays a separate definition-site concern (`Assert<IsValid<T>>`).
- Version bumped to v0.10.8 (0.10.7 already published).

## Test evidence

- `pnpm run lint` clean; `pnpm run typecheck` (whole monorepo) exit 0; `create-lazy.test.ts` 46 passing.
- New test `validNonConformant`: a service with `fetch(): Promise<Response>` + `Observe<number | undefined>` genuinely **fails** `IsValid` (asserted via `@ts-expect-error`) yet `createLazy` **accepts** it — proving the decouple. Existing schema-mismatch error tests still fail as expected.

## Related PRs

Follows #193 (merged).

## Jira ticket

N/A — follow-up to an exploratory `@adobe/data` addition.

## Checklist

- [x] Code compiles and type-checks (`pnpm run typecheck` — exit 0).
- [x] Lint passes (`pnpm run lint` — clean).
- [x] Tests added/updated — `validNonConformant` covers the new capability; existing createLazy suite (46) passes.
- [x] Version bumped (publishable packages → v0.10.8; private samples not bumped, see `scripts/bump.mjs`).
- [x] Docs/comments — updated `createLazy` JSDoc + the gate type comment to state it does not require `IsValid`.
- [x] Backwards compatible — strictly loosens the gate; every schema that validated before still validates.
